### PR TITLE
RS/CH/ improve missing context reporting

### DIFF
--- a/rct229/reports/utils.py
+++ b/rct229/reports/utils.py
@@ -3,17 +3,18 @@ def aggregate_outcomes(outcomes):
         for outcome in outcomes:
             summary_dict["number_evaluations"] += 1
             result = outcome["result"]
-            if result == "FAILED":
-                summary_dict["number_failed"] += 1
-            elif result == "PASSED":
-                summary_dict["number_passed"] += 1
-            elif result == "MANUAL_CHECK_REQUIRED":
-                summary_dict["number_manual_check_required"] += 1
-            elif result == "MISSING_CONTEXT":
-                summary_dict["number_missing_context"] += 1
-            elif result == "NA":
-                summary_dict["number_not_applicable"] += 1
-            elif type(result) == list:
+            if type(result) is str:
+                if result == "FAILED":
+                    summary_dict["number_failed"] += 1
+                elif result == "PASSED":
+                    summary_dict["number_passed"] += 1
+                elif result == "MANUAL_CHECK_REQUIRED":
+                    summary_dict["number_manual_check_required"] += 1
+                elif result.startswith("MISSING_"):
+                    summary_dict["number_missing_context"] += 1
+                elif result == "NA":
+                    summary_dict["number_not_applicable"] += 1
+            elif type(result) is list:
                 summary_dict["number_evaluations"] -= 1
                 _count_results(result)
             else:

--- a/rct229/rule_engine/rule_base_test.py
+++ b/rct229/rule_engine/rule_base_test.py
@@ -1,0 +1,69 @@
+import pytest
+from rct229.rule_engine.rule_base import RuleDefinitionBase
+from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
+
+rmr_1 = {
+    "transformers": [
+        {
+            "name": "Transformer 1",
+            "type": "DRY_TYPE",
+            "phase": "SINGLE_PHASE",
+            "efficiency": 0.9,
+            "capacity": 500.0,
+            "peak_load": 500.0,
+        },
+        {
+            "name": "Transformer 2",
+            "type": "DRY_TYPE",
+            "phase": "SINGLE_PHASE",
+            "efficiency": 0.9,
+            "capacity": 500.0,
+            "peak_load": 500.0,
+        },
+    ]
+}
+
+rmr_2 = {
+    "transformers": [
+        {
+            "name": "Transformer 1",
+            "type": "DRY_TYPE",
+            "phase": "SINGLE_PHASE",
+            "efficiency": 0.95,
+            "capacity": 500.0,
+            "peak_load": 500.0,
+        }
+    ]
+}
+
+rmr_empty = {}
+
+# Testing RuleDefinitionBase #########################
+
+base_rule_1 = RuleDefinitionBase(
+    rmr_context="transformers", rmrs_used=UserBaselineProposedVals(True, True, False)
+)
+
+# Testing RuleDefinitionBase get_context method ------------------
+def test__rule_definition_base_get_context__with_missing_rmrs():
+    assert (
+        base_rule_1.get_context(UserBaselineProposedVals(rmr_1, rmr_empty, rmr_2))
+        == "MISSING_BASELINE"
+    )
+    assert (
+        base_rule_1.get_context(UserBaselineProposedVals(rmr_empty, rmr_1, rmr_2))
+        == "MISSING_USER"
+    )
+    assert (
+        base_rule_1.get_context(UserBaselineProposedVals(rmr_empty, rmr_empty, rmr_2))
+        == "MISSING_USER_BASELINE"
+    )
+
+
+def test__rule_definition_base_get_context__with_rmrs_present():
+    context = base_rule_1.get_context(UserBaselineProposedVals(rmr_1, rmr_2, rmr_empty))
+    assert (
+        context.user == rmr_1["transformers"]
+        and context.baseline == rmr_2["transformers"]
+        and context.proposed == None
+    )

--- a/rct229/utils/match_lists_test.py
+++ b/rct229/utils/match_lists_test.py
@@ -20,9 +20,16 @@ def test__match_lists__with_matching_lists():
 
 
 
-def test__match_lists__with_nonmatching_lists():
+def test__match_lists__with_nonmatching_lists_1():
     assert match_lists(
         [{'name': 'A'}, {'name': 'B', 'num': 8}, {'name': 'C'}],
         [{'name': 'H'}, {'name': 'A'}],
         '/name'
     ) == [{'name': 'A'}, None, None]
+
+def test__match_lists__with_nonmatching_lists_2():
+    assert match_lists(
+        [{'name': 'H'}, {'name': 'A'}],
+        [{'name': 'A'}, {'name': 'B', 'num': 8}, {'name': 'C'}],
+        '/name'
+    ) == [None, {'name': 'A'}]


### PR DESCRIPTION
Instead of reporting "MISSING_CONTEXT" when one or more RMR contexts are missing, it now reports "MISSING_" with all the RMRs whose contexts are missing appended.  For example, with both the USER and BASELINE contexts are missing, then "MISSING_USER_BASELINE" is reported.

To see the difference, you will need to create an RMR with a missing context. The easiest way to do that is probably to temporarily modify one of the RMR files in the examples/ folder.  For example, replace the RMR in `baseline_rmr.json` with `{}`.  Then run the command `pipenv run rct229 evaluate examples/user_rmr.json examples/baseline_rmr.json examples/proposed_rmr.json` from the top-level folder.