### PR TITLE
RS/CH/Nested the nested rules

### DIFF
--- a/rct229/cli.py
+++ b/rct229/cli.py
@@ -1,4 +1,5 @@
 import click
+
 from rct229.reports.project_report import (
     print_json_report,
     print_rule_report,

--- a/rct229/rule_engine/rule_base.py
+++ b/rct229/rule_engine/rule_base.py
@@ -1,4 +1,5 @@
 from jsonpointer import resolve_pointer
+
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 from rct229.utils.match_lists import match_lists
 

--- a/rct229/rule_engine/rule_base_test.py
+++ b/rct229/rule_engine/rule_base_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from rct229.rule_engine.rule_base import RuleDefinitionBase
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 

--- a/rct229/rules/section15.py
+++ b/rct229/rules/section15.py
@@ -95,7 +95,7 @@ class Section15Rule3(RuleDefinitionListIndexedBase):
             description="User RMR transformer Name in Proposed RMR",
             rmr_context="transformers",
             rmrs_used=UserBaselineProposedVals(True, False, True),
-            each_rule=Section15Rule3.NameInProposed(),
+            each_rule=Section15Rule3.TransformerRule(),
             index_rmr="user",
         )
 
@@ -103,9 +103,9 @@ class Section15Rule3(RuleDefinitionListIndexedBase):
         # Get the Proposed transformer names
         return find_all("[*].name", context.proposed)
 
-    class NameInProposed(RuleDefinitionBase):
+    class TransformerRule(RuleDefinitionBase):
         def __init__(self):
-            super(Section15Rule3.NameInProposed, self).__init__(
+            super(Section15Rule3.TransformerRule, self).__init__(
                 rmrs_used=UserBaselineProposedVals(True, False, False)
             )
 
@@ -134,7 +134,7 @@ class Section15Rule4(RuleDefinitionListIndexedBase):
             description="User RMR transformer Name in Baseline RMR",
             rmr_context="transformers",
             rmrs_used=UserBaselineProposedVals(True, True, False),
-            each_rule=Section15Rule4.NameInBaseline(),
+            each_rule=Section15Rule4.TransformerRule(),
             index_rmr="user",
         )
 
@@ -142,9 +142,9 @@ class Section15Rule4(RuleDefinitionListIndexedBase):
         # Get the Baseline transformer names
         return find_all("[*].name", context.baseline)
 
-    class NameInBaseline(RuleDefinitionBase):
+    class TransformerRule(RuleDefinitionBase):
         def __init__(self):
-            super(Section15Rule4.NameInBaseline, self).__init__(
+            super(Section15Rule4.TransformerRule, self).__init__(
                 rmrs_used=UserBaselineProposedVals(True, False, False),
             )
 
@@ -173,13 +173,13 @@ class Section15Rule5(RuleDefinitionListIndexedBase):
             description="Transformer efficiency reported in Baseline RMR equals Table 8.4.4",
             rmr_context="transformers",
             rmrs_used=UserBaselineProposedVals(True, True, False),
-            each_rule=Section15Rule5.BaselineEffAsRequired(),
+            each_rule=Section15Rule5.TransformerRule(),
             index_rmr="user",
         )
 
-    class BaselineEffAsRequired(RuleDefinitionBase):
+    class TransformerRule(RuleDefinitionBase):
         def __init__(self):
-            super(Section15Rule5.BaselineEffAsRequired, self).__init__(
+            super(Section15Rule5.TransformerRule, self).__init__(
                 rmrs_used=UserBaselineProposedVals(True, True, False),
             )
 
@@ -245,12 +245,12 @@ class Section15Rule6(RuleDefinitionListIndexedBase):
             description="Transformer efficiency reported in User RMR equals Table 8.4.4",
             rmr_context="transformers",
             rmrs_used=UserBaselineProposedVals(True, False, False),
-            each_rule=Section15Rule6.UserEffAtLeastRequired(),
+            each_rule=Section15Rule6.TransformerRule(),
         )
 
-    class UserEffAtLeastRequired(RuleDefinitionBase):
+    class TransformerRule(RuleDefinitionBase):
         def __init__(self):
-            super(Section15Rule6.UserEffAtLeastRequired, self).__init__(
+            super(Section15Rule6.TransformerRule, self).__init__(
                 rmrs_used=UserBaselineProposedVals(True, False, False),
             )
 

--- a/rct229/ruletest_engine/ruletest_engine.py
+++ b/rct229/ruletest_engine/ruletest_engine.py
@@ -2,9 +2,10 @@ import json
 import os
 
 from rct229.rule_engine.engine import evaluate_rule
-from rct229.schema.validate import validate_rmr
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 from rct229.rules.section15 import *
+from rct229.schema.validate import validate_rmr
+
 
 # Generates the RMR triplet dictionaries from a test_dictionary's "rmr_transformation" element.
 # -test_dict = Dictionary with elements 'rmr_transformations' and 'rmr_transformations/user,baseline,proposed'
@@ -209,7 +210,7 @@ def run_section_tests(test_json_name):
         try:
             rule = globals()[function_name]()
         except KeyError:
-            outcome_text = f'RULE NOT FOUND: {function_name}'
+            outcome_text = f"RULE NOT FOUND: {function_name}"
             test_result_strings.append(outcome_text)
 
             # Append failed message to rule
@@ -245,7 +246,7 @@ def run_section_tests(test_json_name):
                 # Iterate through each outcome in outcome results
                 for outcome in outcome_result:
                     # Append test result for this outcome
-                    outcome_result_list.append(evaluate_outcome(outcome['result']))
+                    outcome_result_list.append(evaluate_outcome(outcome["result"]))
 
                 # Checks that ALL tests pass in test_results. If any fail, the test fails
                 test_result = all(outcome_result_list)
@@ -281,14 +282,14 @@ def run_section_tests(test_json_name):
 
 
 def validate_test_json_schema(test_json_path):
-    """ Evaluates a test JSON against the JSON schema. Raises flags for any errors found in any rule tests. Results
-        are printed to console
+    """Evaluates a test JSON against the JSON schema. Raises flags for any errors found in any rule tests. Results
+    are printed to console
 
-        Parameters
-        ----------
-        test_json_path : string
+    Parameters
+    ----------
+    test_json_path : string
 
-            Path to the test JSON in 'test_jsons' directory. (e.g., transformer_tests.json)
+        Path to the test JSON in 'test_jsons' directory. (e.g., transformer_tests.json)
 
     """
 
@@ -308,12 +309,12 @@ def validate_test_json_schema(test_json_path):
         user_rmr, baseline_rmr, proposed_rmr = generate_test_rmrs(test_dict)
 
         # Evaluate RMRs against the schema
-        user_result = validate_rmr(user_rmr) if user_rmr!= None else None
-        baseline_result =  validate_rmr(baseline_rmr) if baseline_rmr!= None else None
-        proposed_result =  validate_rmr(proposed_rmr) if proposed_rmr!= None else None
+        user_result = validate_rmr(user_rmr) if user_rmr != None else None
+        baseline_result = validate_rmr(baseline_rmr) if baseline_rmr != None else None
+        proposed_result = validate_rmr(proposed_rmr) if proposed_rmr != None else None
 
         results_list = [user_result, baseline_result, proposed_result]
-        rmr_type_list = ['User', 'Baseline', 'Proposed']
+        rmr_type_list = ["User", "Baseline", "Proposed"]
 
         for result, rmr_type in zip(results_list, rmr_type_list):
 
@@ -322,14 +323,14 @@ def validate_test_json_schema(test_json_path):
 
                 if result["passed"] is not True:
 
-                    error_message = result['error']
-                    failure_message = f'Schema validation in {test_id} for the {rmr_type} RMR: {error_message}'
+                    error_message = result["error"]
+                    failure_message = f"Schema validation in {test_id} for the {rmr_type} RMR: {error_message}"
                     failure_list.append(failure_message)
 
     if len(failure_list) == 0:
 
         base_name = os.path.basename(test_json_path)
-        print(f'No schema errors found in {base_name}')
+        print(f"No schema errors found in {base_name}")
         return True
 
     else:
@@ -338,7 +339,6 @@ def validate_test_json_schema(test_json_path):
             print(failure)
 
         return False
-
 
 
 def run_transformer_tests():

--- a/rct229/ruletest_engine/ruletest_jsons/scripts/json_generation_utilities.py
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/json_generation_utilities.py
@@ -3,21 +3,21 @@ import os
 
 
 def get_nested_dict(dic, keys):
-    """ Used to get nested python dictionary strings
-        Example: get_nested_reference_dict(my_dict, ['a', 'b', 'c']) returns my_dict['a']['b']['c']
+    """Used to get nested python dictionary strings
+    Example: get_nested_reference_dict(my_dict, ['a', 'b', 'c']) returns my_dict['a']['b']['c']
 
-        Parameters
-        ----------
-        dic : dictionary
-            Dictionary of nested dictionaries.
-        keys: list
-            Key names used for writing in the nested dictionary
+    Parameters
+    ----------
+    dic : dictionary
+        Dictionary of nested dictionaries.
+    keys: list
+        Key names used for writing in the nested dictionary
 
-        Returns
-        -------
-        dic: dictionary
+    Returns
+    -------
+    dic: dictionary
 
-            Returns the referenced Python dictionary.
+        Returns the referenced Python dictionary.
     """
 
     # Generate a nested dictionary, slowly building on a reference nested dictionary each iteration through the loop.
@@ -59,7 +59,7 @@ def get_nested_dict(dic, keys):
             # the single value specified by the key.
             if is_list:
                 # If list isn't long enough, append a new dictionary to it to avoid index out of bounds
-                if len(reference_dict[key]) < list_index+1:
+                if len(reference_dict[key]) < list_index + 1:
                     reference_dict[key].append({})
                 reference_dict = reference_dict[key][list_index]
             else:
@@ -67,39 +67,39 @@ def get_nested_dict(dic, keys):
 
 
 def parse_key_string(key_string):
-    """ Inspects a string representing a key for any list references. Returns the parsed 'key' and 'list_index' reference
-        Example: 'surfaces[1]' references a key = 'surfaces' which represents a list. The '[1]' implies a reference
-                  to the second element in the 'surfaces' list. This would return both 'surfaces' and 1.
+    """Inspects a string representing a key for any list references. Returns the parsed 'key' and 'list_index' reference
+    Example: 'surfaces[1]' references a key = 'surfaces' which represents a list. The '[1]' implies a reference
+              to the second element in the 'surfaces' list. This would return both 'surfaces' and 1.
 
-        Parameters
-        ----------
-        key_string: str
-            String representing a key and possibly a reference to a list index. Example: 'surfaces[1]'
+    Parameters
+    ----------
+    key_string: str
+        String representing a key and possibly a reference to a list index. Example: 'surfaces[1]'
 
-        Returns
-        -------
-        key: str
-            String parsed out of key_string representing a referenced key.
-        list_index: int
-            Integer representing a list index parsed out of key_string. 'None' if no list reference is found
+    Returns
+    -------
+    key: str
+        String parsed out of key_string representing a referenced key.
+    list_index: int
+        Integer representing a list index parsed out of key_string. 'None' if no list reference is found
 
     """
 
-
     # If key specifies an in index (e.g.., something like "[1]" appended afterward a key name), parse the key and
     # index out from the string
-    if '[' in key_string:
-        split_str = key_string.split('[')
+    if "[" in key_string:
+        split_str = key_string.split("[")
         key = split_str[0]
-        list_index = int(split_str[1].replace(']', ''))
+        list_index = int(split_str[1].replace("]", ""))
     else:
         key = key_string
         list_index = None
 
     return key, list_index
 
+
 def set_nested_dict(dic, keys, value):
-    """ Used to set nested python dictionary strings. Useful for setting dictionary values for JSON generation.
+    """Used to set nested python dictionary strings. Useful for setting dictionary values for JSON generation.
     Example: nested_set(my_dict, ['a', 'b', 'c'], 'my_value') is same as my_dict['a']['b']['c'] = 'my_value'
 
     Parameters
@@ -161,8 +161,8 @@ def inject_json_path_from_enumeration(key_list, json_path_ref_string):
     enumeration_list = path_enum_dict[json_path_enumeration].split("/")
 
     # Append index back onto final key if JSON_PATH was defined as a list:
-    if list_index!= None:
-        enumeration_list[-1] = f'{enumeration_list[-1]}[{list_index}]'
+    if list_index != None:
+        enumeration_list[-1] = f"{enumeration_list[-1]}[{list_index}]"
 
     # Inject enumeration list into keylist
     key_list.extend(enumeration_list)
@@ -243,5 +243,3 @@ def clean_value(value):
                 return value
             except ValueError:
                 return value
-
-

--- a/rct229/ruletest_engine/ruletest_jsons/scripts/run_json_schema_validation.py
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/run_json_schema_validation.py
@@ -1,8 +1,8 @@
 from rct229.ruletest_engine.ruletest_engine import *
 
-test_json_name = 'envelope_tests.json'
+test_json_name = "envelope_tests.json"
 
-json_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'ruletest_jsons')
+json_dir = os.path.join(os.path.dirname(__file__), "..", "..", "ruletest_jsons")
 test_json_path = os.path.join(json_dir, test_json_name)
 
 validate_test_json_schema(test_json_path)

--- a/rct229/ruletest_engine/tests/test_ruletest_json_schemas.py
+++ b/rct229/ruletest_engine/tests/test_ruletest_json_schemas.py
@@ -1,9 +1,9 @@
 from rct229.ruletest_engine.ruletest_engine import *
 
-test_json_dir = os.path.join(os.path.dirname(__file__), '..', 'ruletest_jsons')
+test_json_dir = os.path.join(os.path.dirname(__file__), "..", "ruletest_jsons")
 
-transformer_json_path = os.path.join(test_json_dir, 'transformer_tests.json')
-envelope_json_path = os.path.join(test_json_dir, 'envelope_tests.json')
+transformer_json_path = os.path.join(test_json_dir, "transformer_tests.json")
+envelope_json_path = os.path.join(test_json_dir, "envelope_tests.json")
 
 
 def test_run_transformer_json_schema():

--- a/rct229/utils/match_lists.py
+++ b/rct229/utils/match_lists.py
@@ -27,7 +27,7 @@ def match_lists(index_list, list2, id_pointer):
     """
 
     def id_key(obj):
-        """ Uses id_pointer as a json pointer to select an identifier from an object"""
+        """Uses id_pointer as a json pointer to select an identifier from an object"""
         return resolve_pointer(obj, id_pointer)
 
     # Step through index_list, looking for matches in list2

--- a/rct229/utils/match_lists_test.py
+++ b/rct229/utils/match_lists_test.py
@@ -4,32 +4,33 @@ from match_lists import match_lists
 
 # Testing match_lists()
 def test__match_lists__with_matching_lists():
-    assert match_lists(
-        [
-            {'name': 'A'},
-            {'name': 'B'},
-            {'name': 'C'}
-        ],
-        [
-            {'name': 'B'},
-            {'name': 'A'},
-            {'name': 'C'}
-        ],
-        '/name'
-    ) == [{'name': 'A'}, {'name': 'B'}, {'name': 'C'}]
-
+    assert (
+        match_lists(
+            [{"name": "A"}, {"name": "B"}, {"name": "C"}],
+            [{"name": "B"}, {"name": "A"}, {"name": "C"}],
+            "/name",
+        )
+        == [{"name": "A"}, {"name": "B"}, {"name": "C"}]
+    )
 
 
 def test__match_lists__with_nonmatching_lists_1():
-    assert match_lists(
-        [{'name': 'A'}, {'name': 'B', 'num': 8}, {'name': 'C'}],
-        [{'name': 'H'}, {'name': 'A'}],
-        '/name'
-    ) == [{'name': 'A'}, None, None]
+    assert (
+        match_lists(
+            [{"name": "A"}, {"name": "B", "num": 8}, {"name": "C"}],
+            [{"name": "H"}, {"name": "A"}],
+            "/name",
+        )
+        == [{"name": "A"}, None, None]
+    )
+
 
 def test__match_lists__with_nonmatching_lists_2():
-    assert match_lists(
-        [{'name': 'H'}, {'name': 'A'}],
-        [{'name': 'A'}, {'name': 'B', 'num': 8}, {'name': 'C'}],
-        '/name'
-    ) == [None, {'name': 'A'}]
+    assert (
+        match_lists(
+            [{"name": "H"}, {"name": "A"}],
+            [{"name": "A"}, {"name": "B", "num": 8}, {"name": "C"}],
+            "/name",
+        )
+        == [None, {"name": "A"}]
+    )


### PR DESCRIPTION
The only file with substantive changes is rct229/rules/section15.py.  The rest are from running `isort` and `black`.  Hopefully these formatting changes will settle down once we stop merging in non-formatted branches.

The idea here is to put each nested rule inside the class definition for the outer rule.  This should make the structure clearer while avoiding potential name conflicts.