### PR TITLE
Update _ruleset_functions.md

### DIFF
--- a/docs/_ruleset_functions.md
+++ b/docs/_ruleset_functions.md
@@ -1,33 +1,135 @@
 ## get_zone_conditioning_category
-Description:  Determine the Space Conditioning Category for each zone.  This function would cycle through each space in an RMR and categorize it as ‘conditioned’, semi-heated’ or ‘unconditioned’.  If ‘conditioned’ it will also categorize the space as ‘residential’ or ‘non-residential’.  
+Description: Determine the Zone Conditioning Category for each zone. This function would cycle through each zone in an RMR and categorize it as ‘conditioned’, 'semi-heated’ or ‘unconditioned’.  
 
-Inputs:  
-- **Zone**: A Zone data element from the RMR.  
+Inputs:
+  - **RMR**: The RMR that needs to determine zone conditioning category.  
 
-Returns:  
-- **zone_conditioning_category**: The Zone Conditioning Category [conditioned, semi-heated, unconditioned].
+Returns:
+- **zone_conditioning_category**: The Zone Conditioning Category [conditioned, semi-heated, unconditioned].  
 
-Logic: [FILL IN LOGIC HERE]   
+
+Logic:  
+
+- Get building climate zone: ```climate_zone = RMR.weather.climate_zone```  
+
+  - Get heated space criteria: ```system_min_heating_output = data_lookup(table_3_2,climate_zone)```  
+
+- For each building segment in the RMR: ```for building_segment in RMR.building.building_segments:```  
+
+  - To determine zone conditioning category for zones served by an HVAC system, for each HVAC system in building segment: ```for hvac_system in building_segment.heating_ventilation_air_conditioning_systems:```  
+
+    - Check if the system meets the criteria for serving directly conditioned (heated or cooled) zones, save all zones served by the system as directly conditioned: ```if ( hvac_system.simulation_result_sensible_cool_capacity >= 3.4 ) OR ( hvac_system.simulation_result_heat_capacity >= system_min_heating_output ):  for zone in hvac_system.zones_served: zone_conditioning_category_dict[zone.id] = "DIRECTLY-CONDITIONED"```  
+
+    - Else check if the system meets the criteria for serving semi-heated zones, save all zones served by the system as semi-heated: ```else if hvac_system.simulation_result_heat_capacity >= 3.4: for zone in hvac_system.zones_served: zone_conditioning_category_dict[zone.id] = "SEMI-HEATED"```  
+
+    - Else, save all zones served by the system as unconditioned: ```else: for zone in hvac_system.zones_served: zone_conditioning_category_dict[zone.id] = "UNCONDITIONED"```  
+
+  - To determine zone conditioning category for zones not served by any HVAC system, for each thermal block in building segment: ```for thermal_block in building_segment.thermal_blocks:```  
+
+    - For each zone in thermal block: ```for zone in thermal_block.zones:```  
+
+      - If zone has not been classified: ```if zone.id not in zone_conditioning_category_dict:```  
+
+        - For each surface in zone: ```for surface in zone.surfaces:```  
+
+          - Check if surface is interior: ```if surface.adjacent_to == "INTERIOR":```  
+
+            - If the adjacent zone is directly conditioned (heated or cooled), add the product of the U-factor and surface area to the directly conditioned type: ```if zone_conditioning_category_dict[surface.adjacent_zone_id] == "DIRECTLY-CONDITIONED": directly_conditioned_product_sum += sum( ( fenestration.glazed_area + fenestration.opaque_area ) * fenestration.u_factor for fenestration in surface.fenestration_subsurfaces ) + ( surface.area - sum( ( fenestration.glazed_area + fenestration.opaque_area ) for fenestration in surface.fenestration_subsurfaces ) * surface.construction.u_factor```  
+
+            - Else, add the product of the U-factor and surface area to the other type (outdoor, semi-heated or unconditioned): ```else: other_product_sum += sum( ( fenestration.glazed_area + fenestration.opaque_area ) * fenestration.u_factor for fenestration in surface.fenestration_subsurfaces ) + ( surface.area - sum( ( fenestration.glazed_area + fenestration.opaque_area ) for fenestration in surface.fenestration_subsurfaces ) * surface.construction.u_factor```  
+
+          - Else check if surface is exterior, add the product of the U-factor and surface area to the other type (outdoor, semi-heated or unconditioned): ```else if surface.adjacent_to == "EXTERIOR": other_product_sum += sum( ( fenestration.glazed_area + fenestration.opaque_area ) * fenestration.u_factor for fenestration in surface.fenestration_subsurfaces ) + ( surface.area - sum( ( fenestration.glazed_area + fenestration.opaque_area ) for fenestration in surface.fenestration_subsurfaces ) * surface.construction.u_factor```  
+
+      - Determine if the zone is indirectly conditioned: ```if directly_conditioned_product_sum > other_product_sum: zone_conditioning_category_dict[zone.id] = "INDIRECTLY-CONDITIONED"```  
+
+      - Else, zone is unconditioned: ```else: zone_conditioning_category_dict[zone.id] = "UNCONDITIONED"```  
+
+- Save all directly and indirectly conditioned zones as conditioned: ```for key in zone_conditioning_category_dict: if ( zone_conditioning_category_dict[key] == "DIRECTLY-CONDITIONED" ) OR ( zone_conditioning_category_dict[key] == "INDIRECTLY-CONDITIONED" ): zone_conditioning_category_dict[key] == "CONDITIONED"```  
+
+**Returns** ```return zone_conditioning_category_dict```
 
 ## get_surface_conditioning_category
-Description:  Determine Surface Conditioning Category for each Surface of a Zone.  
+Description: Determine Surface Conditioning Category for each Surface of all Zones in RMR.  
 
-Inputs:  
-- **ADD_HERE**: Description of inputs.  
+Inputs:
 
-Returns:  
-- **ADD_HERE**: Description of output.  
+  - **RMR**: The RMR that needs to determine surface conditioning category.  
 
-Logic: [FILL IN LOGIC HERE]   
+Returns:
 
+  - **surface_conditioning_category**: The Surface Conditioning Category [conditioned, semi-heated, unregulated].  
+
+Logic:  
+
+- Get zone conditioning category dictionary for the RMR: ```zone_conditioning_category_dict = get_zone_conditioning_category(RMR)```  
+
+- For each building segment in the RMR: ```for building_segment in RMR.building.building_segments:```  
+
+  - For each thermal block in building segment: ```for thermal_block in building_segment.thermal_blocks:```  
+
+    - For each zone in thermal block: ```for zone in thermal_block.zones:```  
+
+      - If zone is conditioned: ```if zone_conditioning_category_dict[zone.id] == "CONDITIONED":```  
+
+        - For each surface in zone: ```for surface in zone.surfaces:```  
+
+          - Check if surface adjacency is exterior or ground, surface is classified as conditioned: ```if ( surface.adjacent_to == "EXTERIOR" ) OR ( surface.adjacent_to == "GROUND" ): surface_conditioning_category_dict[surface.id] = "CONDITIONED"```  
+
+          - Else if surface adjacency is interior, get adjacent zone: ```else if surface.adjacent_to == "INTERIOR": adjacent_zone = match_data_element(RMR, zones, surface.adjacent_zone_id)```  
+
+            - Check if adjacent zone is conditioned, surface is classified as unregulated: ```if zone_conditioning_category_dict(adjacent_zone) == "CONDITIONED": surface_conditioning_category_dict[surface.id] = "UNREGULATED"```  
+
+            - Else, adjacent zone is semi-heated or unconditioned, surface is classified as semi-heated: ```else: surface_conditioning_category_dict[surface.id] = "SEMI-HEATED"```  
+
+          - Else, surface adjacency is identical or undefined, surface is classified as unregulated: ```else: surface_conditioning_category_dict[surface.id] = "UNREGULATED"```  
+
+      - Else if zone is semi-heated: ```else if: zone_conditioning_category_dict[zone.id] == "SEMI-HEATED":```  
+
+        - For each surface in zone: ```for surface in zone.surfaces:```  
+
+          - Check if surface adjacency is exterior or ground, surface is classified as semi-heated: ```if ( surface.adjacent_to == "EXTERIOR" ) OR ( surface.adjacent_to == "GROUND" ): surface_conditioning_category_dict[surface.id] = "SEMI-HEATED"```  
+
+          - Else if surface adjacency is interior, get adjacent zone: ```else if surface.adjacent_to == "INTERIOR": adjacent_zone = match_data_element(RMR, zones, surface.adjacent_zone_id)```  
+
+            - Check if adjacent zone is conditioned or unconditioned, surface is classified as semi-heated: ```if ( zone_conditioning_category_dict(adjacent_zone) == "CONDITIONED" ) OR ( zone_conditioning_category_dict(adjacent_zone) == "UNCONDITIONED" ): surface_conditioning_category_dict[surface.id] = "SEMI-HEATED"```  
+
+            - Else, adjacent zone is semi-heated, surface is classified as unregulated: ```else: surface_conditioning_category_dict[surface.id] = "UNREGULATED"```  
+
+          - Else, surface adjacency is identical or undefined, surface is classified as unregulated: ```else: surface_conditioning_category_dict[surface.id] = "UNREGULATED"```  
+
+      - Else, zone is unconditioned: ```else:```  
+
+        - For each surface in zone: ```for surface in zone.surfaces:```  
+
+          - Check if surface adjacency is exterior or ground, surface is classified as unregulated: ```if ( surface.adjacent_to == "EXTERIOR" ) OR ( surface.adjacent_to == "GROUND" ): surface_conditioning_category_dict[surface.id] = "UNREGULATED"```  
+
+          - Else if surface adjacency is interior, get adjacent zone: ```else if surface.adjacent_to == "INTERIOR": adjacent_zone = match_data_element(RMR, zones, surface.adjacent_zone_id)```  
+
+            - Check if adjacent zone is conditioned or semi-heated, surface is classified as semi-heated: ```if ( zone_conditioning_category_dict(adjacent_zone) == "CONDITIONED" ) OR ( zone_conditioning_category_dict(adjacent_zone) == "SEMI-HEATED" ): surface_conditioning_category_dict[surface.id] = "SEMI-HEATED"```  
+
+            - Else, adjacent zone is unconditioned, surface is classified as unregulated: ```else: surface_conditioning_category_dict[surface.id] = "UNREGULATED"```  
+
+          - Else, surface adjacency is identical or undefined, surface is classified as unregulated: ```else: surface_conditioning_category_dict[surface.id] = "UNREGULATED"```  
+
+**Returns** ```return surface_conditioning_category_dict```  
 
 ## get_opaque_surface_type
-Description:  This function would cycle through each surface and determine whether it is a wall, ceiling or floor.  
+Description: This function would determine whether it is a wall, ceiling or floor.  
 
-Inputs:  
-- **ADD_HERE**: Description of inputs.  
+Inputs:
+  - **Surface**: The surface that needs to determine surface type.  
 
-Returns:  
-- **ADD_HERE**: Description of output.  
+Returns:
+- **opaque_surface_type**: The Opaque Surface Type [wall, ceiling, floor].  
 
-Logic: [FILL IN LOGIC HERE]   
+
+Logic:  
+
+- If surface tilt is more than or equal to 0 degree and less than 60 degrees, surface is classified as ceiling: ```if 0 <= surface.tilt < 60: surface_type == "CEILING"```  
+
+- Else if surface tile is more than 120 degrees and less than or equal to 180 degrees, surface is classified as floor: ```else if 120 < surface.tilt <= 180: surface_type == "FLOOR"```  
+
+- Else, surface is classified as wall: ```else: surface_type == "WALL"```
+
+**Returns** ```return surface_type```
+

--- a/docs/_ruleset_functions.md
+++ b/docs/_ruleset_functions.md
@@ -218,3 +218,53 @@ Logic:
   - Else determine if surface is above grade wall: ```else: surface_type = "ABOVE-GRADE WALL"```  
 
 **Returns** ```return surface_type```  
+
+## get_wwr
+
+Description: This function would determine window wall ratio for a building segment.  
+
+Inputs:
+  - **RMR**: The RMR that needs to determine window wall ratio.  
+
+Returns:
+- **window_wall_ratio**: The window wall ratio of the building segment.  
+
+Function Call:
+
+- get_zone_conditioning_category()
+- get_surface_conditioning_category()
+- get_opaque_surface_type()
+
+Logic:
+
+- Get zone conditioning category dictionary for RMR: `zcc_dictionary = get_zone_conditioning_category(RMR)`
+
+- Get surface conditioning category dictionary for RMR: `scc_dictionary = get_surface_conditioning_category(RMR)`
+
+- For each building segment in the model: `for building_segment in RMR.building.building_segments:`
+
+  - For each thermal_block in building segment: `for thermal_block in building_segment.thermal_blocks:`
+
+    - For each zone in thermal block: `zone in thermal_block.zones:`
+
+      - Check if zone is conditioned or semi-heated: `if zcc_dictionary[zone.id] in [CONDITIONED RESIDENTIAL, CONDITIONED NON-RESIDENTIAL, CONDITIONED MIXED, SEMI-HEATED]`
+
+        - For each surface in zone: `for surface in zone.surfaces:`
+
+          - If surface is above-grade wall and adjacent to the exterior: `if ((get_opaque_surface_type(surface) == "ABOVE-GRADE WALL") AND (surface.adjacent_to == "EXTERIOR")):`  
+
+            - For each subsurface in surface: `for subsurface in surface.subsurfaces:`  
+
+              - If the glazed vision area is less than 50% of the total area, add glazed vision area to building segment total fenestration area: `if ( subsurface.glazed_area < ( subsurface.glazed_area + subsurface.opaque_area ) * 50% ): total_fenestration_area += subsurface.glazed_area`  
+
+              - Else, add total subsurface area to building segment total fenestration area: `else: total_fenestration_area += subsurface.glazed_area + subsurface.opaque_area`  
+
+      - For each surface in zone: `for surface in zone.surfaces:`
+
+        - If surface is above-grade wall and is regulated: `if ((get_opaque_surface_type(surface) == "ABOVE-GRADE WALL") AND (scc_dictionary[surface.id] != "UNREGULATED")):`
+
+          - Add to envelope total above-grade wall area: `total_envelope_wall_area += surface.area`
+
+- Calculate WWR of the building segment: `window_wall_ratio = total_fenestration_area / total_envelope_wall_area`
+
+**Returns** ```return window_wall_ratio```  

--- a/docs/_ruleset_functions.md
+++ b/docs/_ruleset_functions.md
@@ -255,9 +255,7 @@ Logic:
 
             - For each subsurface in surface: `for subsurface in surface.subsurfaces:`  
 
-              - If the glazed vision area is less than 50% of the total area, add glazed vision area to building segment total fenestration area: `if ( subsurface.glazed_area < ( subsurface.glazed_area + subsurface.opaque_area ) * 50% ): total_fenestration_area += subsurface.glazed_area`  
-
-              - Else, add total subsurface area to building segment total fenestration area: `else: total_fenestration_area += subsurface.glazed_area + subsurface.opaque_area`  
+              - If the glazed vision area is more than 50% of the total area, add glazed vision area to building segment total fenestration area: `if ( subsurface.glazed_area > ( subsurface.glazed_area + subsurface.opaque_area ) * 50% ): total_fenestration_area += subsurface.glazed_area + subsurface.opaque_area`  
 
       - For each surface in zone: `for surface in zone.surfaces:`
 

--- a/docs/_ruleset_functions.md
+++ b/docs/_ruleset_functions.md
@@ -196,16 +196,12 @@ Inputs:
   - **Surface**: The surface that needs to determine surface type.  
 
 Returns:
-- **opaque_surface_type**: The Opaque Surface Type [roof, heated slab-on-grade, unheated slab-on-grade, floor, above-grade wall, below-grade wall, unregulated].  
+- **opaque_surface_type**: The Opaque Surface Type [roof, heated slab-on-grade, unheated slab-on-grade, floor, above-grade wall, below-grade wall].  
 
 
 Logic:  
 
-- If surface tilt is more than or equal to 0 degree and less than 60 degrees, surface is classified as roof: ```if 0 <= surface.tilt < 60:```  
-
-  - Determine if surface is roof: ```if surface.adjacent_to == "EXTERIOR": surface_type = "ROOF"```  
-
-  - Else, surface is unregulated: ```else: surface_type = "UNREGULATED"```  
+- If surface tilt is more than or equal to 0 degree and less than 60 degrees, surface is classified as roof: ```if 0 <= surface.tilt < 60: surface_type = "ROOF"```  
 
 - Else if surface tile is more than 120 degrees and less than or equal to 180 degrees, surface is classified as floor: ```else if 120 < surface.tilt <= 180:```  
 
@@ -213,16 +209,12 @@ Logic:
 
   - Else determine if surface is unheated slab-on-grade: ```else if surface.adjacent_to == "GROUND": surface_type = "UNHEATED SLAB-ON-GRADE"```  
 
-  - Else determine if surface is exposed floor: ```else if surface.adjacent_to == "EXTERIOR": surface_type = "FLOOR"```  
-
-  - Else, surface is unregulated: ```else: surface_type = "UNREGULATED"```  
+  - Else, surface is floor: ```else: surface_type = "FLOOR"```  
 
 - Else, surface is classified as wall: ```else:```  
 
   - Determine if surface is below grade wall: ```if surface.adjacent_to == "GROUND": surface_type = "BELOW-GRADE WALL"```  
 
-  - Else determine if surface is above grade wall: ```else if surface.adjacent_to == "EXTERIOR": surface_type = "ABOVE-GRADE WALL"```  
-
-  - Else, surface is unregulated: ```else: surface_type = "UNREGULATED"```  
+  - Else determine if surface is above grade wall: ```else: surface_type = "ABOVE-GRADE WALL"```  
 
 **Returns** ```return surface_type```  


### PR DESCRIPTION
A few notes/questions I have:
**get_zone_conditioning_category**
1. It seems that the criteria for indirectly conditioned spaces is based on heated/cooled space vs outdoor/uncondiioned/semiheated spaces. So other indirectly conditioned spaces are not part of the consideration in the function right now. 

> indirectly conditioned space: an enclosed space within a building that is not a heated space or a cooled space, which is heated or cooled indirectly by being connected to adjacent spaces, provided: 
1.the product of the U-factors and surface areas of the space adjacent to connected spaces exceeds the combined sum of the product of the U-factors and surface areas of the space adjoining the outdoors, unconditioned spaces, and to or from semiheated spaces (e.g., corridors)

2. For the second type of indirectly conditioned spaces, i.e. transfer air from heated or cooled space > 3ACH, will the baseline have transfer air? If not, maybe we do not need to manually check this?

**get_surface_conditioning_category**
1. Can we keep the residential/non-residential determination in the actual RDS instead of putting it in the function? To have it in the function, we would need to check the actual envelope construction table (Table G3.4) and differentiate surface type (wall, ceiling, floor) if we want to raise warning when the residential construction is different from the non-res construction. And we also need to check subsurface, as sometimes the surface has same construction but the subsurface doesn't. This seems to make the function distracted. 

2. I'm still not clear if zone.surfaces only returns surfaces surrounding a zone (as is noted in the schema) or returns all surfaces that defines all spaces in the zone. If the former, and in cases where the zone has both res and non-res spaces and the residential and non-res baseline constructions are different, how can we do manual check (and do we need to raise warning)? It seems there's no indicator of whether the surface belongs to the residential or non-residential space. 