### PR TITLE
RS/CH/upgrade table utils

### DIFF
--- a/rct229/data_fns/table_G3_7_fns.py
+++ b/rct229/data_fns/table_G3_7_fns.py
@@ -134,8 +134,7 @@ def table_G3_7_lpd(lighting_space_type, space_height):
     ]
 
     osstd_entry = find_osstd_table_entry(
-        match_field_value=lpd_space_type,
-        match_field_name="lpd_space_type",
+        [("lpd_space_type", lpd_space_type)],
         osstd_table=data["ashrae_90_1_prm_2019.prm_interior_lighting"],
     )
     watts_per_sqft = osstd_entry["w/ft^2"]

--- a/rct229/data_fns/table_G3_8_fns.py
+++ b/rct229/data_fns/table_G3_8_fns.py
@@ -58,8 +58,7 @@ def table_G3_8_lpd(building_area_type):
     ]
 
     osstd_entry = find_osstd_table_entry(
-        match_field_value=lpd_space_type,
-        match_field_name="lpd_space_type",
+        [("lpd_space_type", lpd_space_type)],
         osstd_table=data["ashrae_90_1_prm_2019.prm_interior_lighting"],
     )
     watts_per_sqft = osstd_entry["w/ft^2"]

--- a/rct229/data_fns/table_utils.py
+++ b/rct229/data_fns/table_utils.py
@@ -1,21 +1,21 @@
 from rct229.data.schema_enums import schema_enums
 
 
-def find_osstd_table_entry(match_field_value, match_field_name, osstd_table):
+def find_osstd_table_entry(match_field_name_value_pairs, osstd_table):
     """Find a specific entry in an OSSTD table
 
     This takes advantage of the consistent structure accross all the OSSTD
     JSON files. Each file contains a dictionary with a single key. The value
     associated with that key is a list of dictionaries. This function searches
-    through those inner dictionaries to find one with a matching
-    match_field_name: match_field_value pair.
+    through those inner dictionaries to find one that matches all the
+    provided
+    match_field_name: match_field_value
+    pairs.
 
     Parameters
     ----------
-    match_field_value : any
-        The matching value for the match_field_name field
-    match_field_name : str
-        The matching field name
+    match_field_name_value_pairs : list of 2-tuples
+        List of (match_field_name, match_field_value) tuples
     osstd_table : dict
         The OSSTD table data as loaded from its JSON file
 
@@ -32,10 +32,25 @@ def find_osstd_table_entry(match_field_value, match_field_name, osstd_table):
     data_list = osstd_table[keys[0]]
     assert type(data_list) is list
 
+    print("match_field_name_value_pairs", match_field_name_value_pairs)
+
     matching_entries = list(
-        filter(lambda entry: entry[match_field_name] == match_field_value, data_list)
+        filter(
+            lambda entry: all(
+                [
+                    entry[match_field_name] == match_field_value
+                    for (
+                        match_field_name,
+                        match_field_value,
+                    ) in match_field_name_value_pairs
+                ]
+            ),
+            data_list,
+        )
     )
-    assert len(matching_entries) == 1, f"Not exactly one {match_field_value} in OSSTD"
+    assert (
+        len(matching_entries) == 1
+    ), f"Not exactly one match in OSSTD for {match_field_name_value_pairs}"
 
     matching_entry = matching_entries[0]
     assert type(matching_entry) is dict
@@ -50,6 +65,37 @@ def check_enumeration_to_osstd_match_field_value_map(
     enumeration_to_match_field_value_map,
     exclude_enum_names=[],
 ):
+    """A sanity check for an enumeration to OSSTD match field value map
+
+    Checks that
+    1. Each enumerated value (except for those in exclude_enum_names) is a
+       key in the map
+    2. There is actually a matching entry in the underlying OSSTD table
+       corresponding to each enumated value
+
+    This function only applies to OSSTD tables that have a field name,
+    match_field_name, whose values are unique in the OSSTD table.
+
+    Parameters
+    ----------
+    match_field_name : str
+        Field name for the OSSTD lookup
+    enum_type : str
+        The name of an enumeration from the ruleset
+    osstd_table : dict
+        An OSSTD table
+    enumeration_to_match_field_value_map : dict
+        The map to be checked
+    exclude_enum_names: list
+        A list of strings of the enumeration names to be excluded from the check
+        For example, "NONE" may be used as a flag that is not intended to be
+        looked up.
+
+    Returns
+    -------
+    dict
+        The matching table entry
+    """
     schema_enum = schema_enums[enum_type]
     for e in schema_enum:
         e_name = e.name
@@ -62,4 +108,6 @@ def check_enumeration_to_osstd_match_field_value_map(
 
         # Make sure there is a corresponding entry in the OSSTD table
         # find_osstd_table_entry() will throw if not
-        entry = find_osstd_table_entry(match_field_value, match_field_name, osstd_table)
+        entry = find_osstd_table_entry(
+            [(match_field_name, match_field_value)], osstd_table
+        )

--- a/rct229/data_fns/table_utils_test.py
+++ b/rct229/data_fns/table_utils_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from rct229.data_fns.table_utils import find_osstd_table_entry
 
 FAKE_OSSTD_TABLE = {
@@ -16,10 +15,9 @@ FAKE_OSSTD_TABLE = {
 }
 
 
-def test__find_osstd_table_entry():
+def test__find_osstd_table_entry__with_single_pair():
     assert find_osstd_table_entry(
-        match_field_value=2,
-        match_field_name="match_field",
+        [("match_field", 2)],
         osstd_table=FAKE_OSSTD_TABLE,
     ) == {
         "match_field": 2,


### PR DESCRIPTION
This allows the find_osstd_table_entry() function to accept multiple (field name, field value) pairs to match.