### PR TITLE
Clarification on Rule5-2 RDS

### DIFF
--- a/docs/section5/Rule5-2.md
+++ b/docs/section5/Rule5-2.md
@@ -10,7 +10,7 @@
 **Applicability Checks:** None  
 
 **Manual Check:** None  
-**Evaluation Context:** Each Data Element  
+**Evaluation Context:** Building Segment  
 **Data Lookup:** None  
 
 ## Rule Logic:  
@@ -27,8 +27,7 @@
 
           - If surface azimuth in P_RMR does not match U_RMR, flag surface: ```if surface_p.azimuth != surface_u.azimuth: surface_check.append(surface)```  
 
-**Rule Assertion:**  
-
-Case 1: All surface azimuth in P_RMR matches U-RMR: ```if NOT surface_check: PASS```  
-
-Case 2: Else: ```else: FAIL```  
+            - **Rule Assertion:**  
+              Case 1: All surface azimuth in P_RMR matches U-RMR: ```if len(surface_check) == 0: PASS```  
+              
+              Case 2: Else: ```else: FAIL```  

--- a/docs/section5/Rule5-2.md
+++ b/docs/section5/Rule5-2.md
@@ -10,7 +10,7 @@
 **Applicability Checks:** None  
 
 **Manual Check:** None  
-**Evaluation Context:** Building Segment  
+**Evaluation Context:** Building  
 **Data Lookup:** None  
 
 ## Rule Logic:  
@@ -27,7 +27,7 @@
 
           - If surface azimuth in P_RMR does not match U_RMR, flag surface: ```if surface_p.azimuth != surface_u.azimuth: surface_check.append(surface)```  
 
-            - **Rule Assertion:**  
-              Case 1: All surface azimuth in P_RMR matches U-RMR: ```if len(surface_check) == 0: PASS```  
-              
-              Case 2: Else: ```else: FAIL```  
+- **Rule Assertion:**  
+  Case 1: All surface azimuth in P_RMR matches U-RMR: ```if len(surface_check) == 0: PASS```  
+
+  Case 2: Else: ```else: FAIL```  


### PR DESCRIPTION
We are looking to have more clarification in the RDS about the evaluation context for the rules.  I discussed with @charliepnnl and we agree that it would be more useful for the "Evaluation Context" field to describe the data group that a rule is evaluated at.  We are proposing that this is updated to "Building" for this rule.  This would mean that the rule assertion is conducted one time for each building after collecting the list of all surfaces with non-matching orientations.  The list of surfaces is obtained by comparing each orientation for all surfaces in the building.