### PR TITLE
RCT/CH/set_black_version

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-python@v2
         # This will halt the action if formatting fails
         # Note: This will also fail if there are syntax errors
-      - uses: psf/black@stable
+      - uses: psf/black@21.10b0
   run-pytests:
     name: Run pytests
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,7 +16,9 @@ jobs:
         uses: actions/setup-python@v2
         # This will halt the action if formatting fails
         # Note: This will also fail if there are syntax errors
-      - uses: psf/black@21.10b0
+      - uses: psf/black@stable
+        with:
+          version: "21.10b0"
   run-pytests:
     name: Run pytests
     runs-on: 'ubuntu-latest'

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.7"
 [dev-packages]
 pylint = "*"
 pytest = "*"
-black = "*"
+black = "21.10b0"
 isort = "*"
 icecream = "*"
 


### PR DESCRIPTION
This is intended to fix the issue with a failing github action. The problem is that a new version of black has been release which the github action was using. But our code was formatted with an older version of black that has slightly different formatting. The simplest solutions seemed to be to explicitly set the version used by the github action to match our own code version.

I also set the version of black in the PipFile so will not inadvertently get the new version if we reinstall on our local machines.