### PR TITLE
RS/CH/Rule5-21-list_filter

### DIFF
--- a/rct229/rules/section5/section5rule21.py
+++ b/rct229/rules/section5/section5rule21.py
@@ -52,6 +52,19 @@ class Section5Rule21(RuleDefinitionListIndexedBase):
                 required_fields={},
                 each_rule=Section5Rule21.BuildingRule.AboveGradeWallRule(),
                 index_rmr="baseline",
+                # list_path and list_filter together determine the list of
+                # above grade walls to be passed to AboveGradeWallRule
+                list_path="$..surfaces[*]",
+                list_filter=(
+                    lambda list_item, data=None: get_opaque_surface_type(
+                        list_item.baseline
+                    )
+                    == OST.ABOVE_GRADE_WALL
+                    and data["surface_conditioning_category_dict_b"][
+                        list_item.baseline["id"]
+                    ]
+                    != SCC.UNREGULATED
+                ),
             )
 
         def create_data(self, context, data=None):
@@ -80,29 +93,6 @@ class Section5Rule21(RuleDefinitionListIndexedBase):
                     data["climate_zone"], building_b
                 ),
             }
-
-        def create_context_list(self, context, data=None):
-            building_b = context.baseline
-            building_p = context.proposed
-
-            scc = data["surface_conditioning_category_dict_b"]
-
-            baseline_surfaces = find_all("$..surfaces[*]", building_b)
-            proposed_surfaces = find_all("$..surfaces[*]", building_p)
-
-            matched_proposed_surfaces = match_lists_by_id(
-                baseline_surfaces, proposed_surfaces
-            )
-            proposed_baseline_surface_pairs = zip(
-                baseline_surfaces, matched_proposed_surfaces
-            )
-            # List of all baseline above grade wall to become the context for AboveGradeWall
-            return [
-                UserBaselineProposedVals(None, surface_b, surface_p)
-                for surface_b, surface_p in proposed_baseline_surface_pairs
-                if get_opaque_surface_type(surface_b) == OST.ABOVE_GRADE_WALL
-                and scc[surface_b["id"]] != SCC.UNREGULATED
-            ]
 
         class AboveGradeWallRule(RuleDefinitionBase):
             def __init__(self):

--- a/rct229/rules/section5/section5rule21.py
+++ b/rct229/rules/section5/section5rule21.py
@@ -55,16 +55,6 @@ class Section5Rule21(RuleDefinitionListIndexedBase):
                 # list_path and list_filter together determine the list of
                 # above grade walls to be passed to AboveGradeWallRule
                 list_path="$..surfaces[*]",
-                list_filter=(
-                    lambda list_item, data=None: get_opaque_surface_type(
-                        list_item.baseline
-                    )
-                    == OST.ABOVE_GRADE_WALL
-                    and data["surface_conditioning_category_dict_b"][
-                        list_item.baseline["id"]
-                    ]
-                    != SCC.UNREGULATED
-                ),
             )
 
         def create_data(self, context, data=None):
@@ -93,6 +83,15 @@ class Section5Rule21(RuleDefinitionListIndexedBase):
                     data["climate_zone"], building_b
                 ),
             }
+
+        def list_filter(self, context_item, data=None):
+            surface_b = context_item.baseline
+
+            return (
+                get_opaque_surface_type(surface_b) == OST.ABOVE_GRADE_WALL
+                and data["surface_conditioning_category_dict_b"][surface_b["id"]]
+                != SCC.UNREGULATED
+            )
 
         class AboveGradeWallRule(RuleDefinitionBase):
             def __init__(self):


### PR DESCRIPTION
I am proposing the use of this new `list_filter` initializer argument instead of overriding `create_context_list`.
This supports the pattern:
1.  Provide a `list_path` json path to obtain matched context lists,
2. Provide a `list_filter` boolean function (a lambda function when the filter isn't too complex) to further refine the context lists from step 1.

