### PR TITLE
Rs/ch/enumerations as classes

### DIFF
--- a/rct229/data/schema_enums.py
+++ b/rct229/data/schema_enums.py
@@ -4,6 +4,30 @@ from os.path import dirname, join
 
 from jsonpath_ng import parse
 
+"""This module exports the dictionary schema_enums that provides access to the
+enumerations in the schema files.
+
+The keys of schema_enums are the names of the enumeration objects; each value
+is a class with an attribute for each item in the enumeration. The value
+of the attribute is the same as the attribute name.
+"""
+
+
+class _ListEnum:
+    """A utility class used to convert a list into a class
+
+    Each item in the list becomes a class attribute whose value is the attribute
+    name as a string. This is intended as a more convenient version of Enum.
+    """
+
+    def __init__(self, _dict):
+        for key in _dict:
+            setattr(self, key, key)
+
+    def get_list(self):
+        return list(self.__dict__.keys())
+
+
 # Load the enumeration schema file
 _enum_schema_path = join(
     dirname(__file__), "..", "schema", "Enumerations2019ASHRAE901.schema.json"
@@ -20,23 +44,16 @@ with open(schema_path) as json_file:
 # See jsonpath docs for parse syntax: https://pypi.org/project/jsonpath-ng/
 _enum_schema_matches = parse("$..* where enum").find(_enum_schema_obj)
 _schema_matches = parse("$..* where enum").find(_schema_obj)
-# Concatinate the two match lists using a list comprehension
-# _match_list = [
-#     match for matches in [_enum_schema_matches, _schema_matches] for match in matches
-# ]
+# Concatinate the two match lists
 _match_list = [*_enum_schema_matches, *_schema_matches]
 
 # Create a dictionary of all the enumerations as dictionaries
-_enum_dicts = {
-    str(match.full_path).split(".")[-1]: dict(
-        (key, value)
-        for key, value in zip(match.value["enum"], match.value["descriptions"])
-    )
-    for match in _match_list
+_enums_dict = {
+    str(match.full_path).split(".")[-1]: match.value["enum"] for match in _match_list
 }
 
-# Convert the enumerations as dictionaries to actual Enums
-schema_enums = {key: Enum(key, enum_dict) for key, enum_dict in _enum_dicts.items()}
+# Convert the enumerations as dictionaries to classess for easier access
+schema_enums = {key: _ListEnum(enum_list) for key, enum_list in _enums_dict.items()}
 
 
 def print_schema_enums():
@@ -46,8 +63,8 @@ def print_schema_enums():
     """
     for key in schema_enums:
         print(f"{key}:")
-        for e in schema_enums[key]:
-            print(f"    {e.name}: {e.value}")
+        for e in schema_enums[key].get_list():
+            print(f"    {e}")
         print()
 
 

--- a/rct229/data/schema_enums.py
+++ b/rct229/data/schema_enums.py
@@ -59,7 +59,7 @@ schema_enums = {key: _ListEnum(enum_list) for key, enum_list in _enums_dict.item
 def print_schema_enums():
     """Print all the schema enumerations with their names and values
 
-    This is primarily useful for debuggin purposes
+    This is primarily useful for debugging purposes
     """
     for key in schema_enums:
         print(f"{key}:")
@@ -69,4 +69,4 @@ def print_schema_enums():
 
 
 # Uncomment this for checking the enumerations after a schema change
-print_schema_enums()
+# print_schema_enums()

--- a/rct229/data/schema_enums.py
+++ b/rct229/data/schema_enums.py
@@ -21,9 +21,10 @@ with open(schema_path) as json_file:
 _enum_schema_matches = parse("$..* where enum").find(_enum_schema_obj)
 _schema_matches = parse("$..* where enum").find(_schema_obj)
 # Concatinate the two match lists using a list comprehension
-_match_list = [
-    match for matches in [_enum_schema_matches, _schema_matches] for match in matches
-]
+# _match_list = [
+#     match for matches in [_enum_schema_matches, _schema_matches] for match in matches
+# ]
+_match_list = [*_enum_schema_matches, *_schema_matches]
 
 # Create a dictionary of all the enumerations as dictionaries
 _enum_dicts = {
@@ -51,4 +52,4 @@ def print_schema_enums():
 
 
 # Uncomment this for checking the enumerations after a schema change
-# print_schema_enums()
+print_schema_enums()

--- a/rct229/data_fns/table_3_2_fns_test.py
+++ b/rct229/data_fns/table_3_2_fns_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from rct229.data import data
-from rct229.data.schema_enums import schema_enums
 from rct229.data_fns.table_3_2_fns import (
     climate_zone_enumeration_to_climate_zone_map,
     table_3_2_lookup,

--- a/rct229/data_fns/table_8_4_4_fns.py
+++ b/rct229/data_fns/table_8_4_4_fns.py
@@ -5,8 +5,8 @@ from rct229.data.schema_enums import schema_enums
 from rct229.schema.config import ureg
 
 ElectricalPhase = schema_enums["ElectricalPhase"]
-SINGLE_PHASE = ElectricalPhase.SINGLE_PHASE.name
-THREE_PHASE = ElectricalPhase.THREE_PHASE.name
+SINGLE_PHASE = ElectricalPhase.SINGLE_PHASE
+THREE_PHASE = ElectricalPhase.THREE_PHASE
 _table_8_4_4 = data["ashrae_90_1_prm_transformers"]
 
 kVA = ureg("kilovolt * ampere")

--- a/rct229/data_fns/table_9_5_1_fns_test.py
+++ b/rct229/data_fns/table_9_5_1_fns_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from rct229.data import data
-from rct229.data.schema_enums import schema_enums
 from rct229.data_fns.table_9_5_1_fns import (
     lighting_space_type_enumeration_to_lpd_map,
     table_9_5_1_lookup,

--- a/rct229/data_fns/table_G3_111_fns_test.py
+++ b/rct229/data_fns/table_G3_111_fns_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from rct229.data import data
-from rct229.data.schema_enums import schema_enums
 from rct229.data_fns.table_G3_111_fns import (
     VERTICAL_FENESTRATION_BUILDING_AREA_TYPE_TO_WWR_BUILDING_TYPE_MAP,
     table_G3_1_1_1_lookup,

--- a/rct229/data_fns/table_G3_6_fns_test.py
+++ b/rct229/data_fns/table_G3_6_fns_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from rct229.data import data
-from rct229.data.schema_enums import schema_enums
 from rct229.data_fns.table_G3_6_fns import (
     EXTERIOR_LIGHTING_AREA_ENUMERATION_TO_BUILDING_EXTERIOR_TYPE_MAP,
     table_G3_6_lookup,

--- a/rct229/data_fns/table_G3_7_fns.py
+++ b/rct229/data_fns/table_G3_7_fns.py
@@ -114,9 +114,9 @@ lighting_space_enumeration_to_lpd_space_type_map = {
     "WAREHOUSE_STORAGE_AREA_SMALLER_HAND_CARRIED_ITEMS": "warehouse - fine storage",
 }
 
-FULL_AUTO_ON = schema_enums["LightingOccupancyControlType"].FULL_AUTO_ON.name
-PARTIAL_AUTO_ON = schema_enums["LightingOccupancyControlType"].PARTIAL_AUTO_ON.name
-MANUAL_ON = schema_enums["LightingOccupancyControlType"].MANUAL_ON.name
+FULL_AUTO_ON = schema_enums["LightingOccupancyControlType"].FULL_AUTO_ON
+PARTIAL_AUTO_ON = schema_enums["LightingOccupancyControlType"].PARTIAL_AUTO_ON
+MANUAL_ON = schema_enums["LightingOccupancyControlType"].MANUAL_ON
 
 # ATRIUM_LOW_MEDIUM
 def table_G3_7_lookup(

--- a/rct229/data_fns/table_G3_8_fns_test.py
+++ b/rct229/data_fns/table_G3_8_fns_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from rct229.data import data
-from rct229.data.schema_enums import schema_enums
 from rct229.data_fns.table_G3_8_fns import (
     lighting_space_enumeration_to_lpd_space_type_map,
     table_G3_8_lookup,

--- a/rct229/data_fns/table_utils.py
+++ b/rct229/data_fns/table_utils.py
@@ -95,14 +95,13 @@ def check_enumeration_to_osstd_match_field_value_map(
         The matching table entry
     """
     schema_enum = schema_enums[enum_type]
-    for e in schema_enum:
-        e_name = e.name
-        if e_name in exclude_enum_names:
+    for e in schema_enum.__dict__.keys():
+        if e in exclude_enum_names:
             continue
 
         # Make sure each space type in the enumeration is in our map
-        match_field_value = enumeration_to_match_field_value_map[e_name]
-        assert match_field_value is not None, f"{e_name} is not in the map"
+        match_field_value = enumeration_to_match_field_value_map[e]
+        assert match_field_value is not None, f"{e} is not in the map"
 
         # Make sure there is a corresponding entry in the OSSTD table
         # find_osstd_table_entry() will throw if not

--- a/rct229/data_fns/table_utils.py
+++ b/rct229/data_fns/table_utils.py
@@ -94,8 +94,7 @@ def check_enumeration_to_osstd_match_field_value_map(
     dict
         The matching table entry
     """
-    schema_enum = schema_enums[enum_type]
-    for e in schema_enum.__dict__.keys():
+    for e in schema_enums[enum_type].get_list():
         if e in exclude_enum_names:
             continue
 

--- a/rct229/rules/section15/section15rule5.py
+++ b/rct229/rules/section15/section15rule5.py
@@ -6,7 +6,7 @@ from rct229.rule_engine.rule_base import (
 )
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 
-_DRY_TYPE = schema_enums["TransformerType"].DRY_TYPE.name
+_DRY_TYPE = schema_enums["TransformerType"].DRY_TYPE
 
 
 class Section15Rule5(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section15/section15rule6.py
+++ b/rct229/rules/section15/section15rule6.py
@@ -6,7 +6,7 @@ from rct229.rule_engine.rule_base import (
 )
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 
-_DRY_TYPE = schema_enums["TransformerType"].DRY_TYPE.name
+_DRY_TYPE = schema_enums["TransformerType"].DRY_TYPE
 
 
 class Section15Rule6(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section5/section5rule18.py
+++ b/rct229/rules/section5/section5rule18.py
@@ -17,7 +17,7 @@ NONE_WARN_MESSAGE = (
     "Building vertical fenestration area type is missing, manual check is required."
 )
 
-OTHER = schema_enums["VerticalFenestrationBuildingAreaType2019ASHRAE901"].OTHER.name
+OTHER = schema_enums["VerticalFenestrationBuildingAreaType2019ASHRAE901"].OTHER
 
 
 class Section5Rule18(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section5/section5rule21.py
+++ b/rct229/rules/section5/section5rule21.py
@@ -21,7 +21,7 @@ from rct229.utils.match_lists import match_lists_by_id
 from rct229.utils.pint_utils import ZERO
 from rct229.utils.std_comparisons import std_equal
 
-DOOR = schema_enums["SubsurfaceClassificationType"].DOOR.name
+DOOR = schema_enums["SubsurfaceClassificationType"].DOOR
 
 
 class Section5Rule21(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section5/section5rule24.py
+++ b/rct229/rules/section5/section5rule24.py
@@ -19,7 +19,7 @@ from rct229.ruleset_functions.get_surface_conditioning_category_dict import (
 from rct229.utils.jsonpath_utils import find_all
 from rct229.utils.std_comparisons import std_equal
 
-DOOR = schema_enums["SubsurfaceClassificationType"].DOOR.name
+DOOR = schema_enums["SubsurfaceClassificationType"].DOOR
 
 
 class Section5Rule24(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section5/section5rule26.py
+++ b/rct229/rules/section5/section5rule26.py
@@ -19,7 +19,7 @@ from rct229.ruleset_functions.get_surface_conditioning_category_dict import (
 from rct229.utils.jsonpath_utils import find_all
 from rct229.utils.std_comparisons import std_equal
 
-DOOR = schema_enums["SubsurfaceClassificationType"].DOOR.name
+DOOR = schema_enums["SubsurfaceClassificationType"].DOOR
 
 
 class Section5Rule26(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section5/section5rule37.py
+++ b/rct229/rules/section5/section5rule37.py
@@ -23,7 +23,7 @@ MANUAL_CHECK_MSG = "Manual review is required to verify skylight meets U-factor 
 MANUAL_CHECK_APPLICABLE = (
     "The subsurface type is Door, not applicable for the rule-checking"
 )
-DOOR = schema_enums["SubsurfaceClassificationType"].DOOR.name
+DOOR = schema_enums["SubsurfaceClassificationType"].DOOR
 
 
 class Section5Rule37(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section5/section5rule44.py
+++ b/rct229/rules/section5/section5rule44.py
@@ -6,7 +6,7 @@ from rct229.rule_engine.rule_base import (
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 from rct229.utils.jsonpath_utils import find_all
 
-CONSTANT = schema_enums["InfiltrationMethodType"].CONSTANT.name
+CONSTANT = schema_enums["InfiltrationMethodType"].CONSTANT
 
 
 class Section5Rule44(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section5/section5rule5.py
+++ b/rct229/rules/section5/section5rule5.py
@@ -1,4 +1,3 @@
-from rct229.data.schema_enums import schema_enums
 from rct229.data_fns.table_G3_4_fns import table_G34_lookup
 from rct229.rule_engine.rule_base import (
     RuleDefinitionBase,

--- a/rct229/rules/section6/section6rule2.py
+++ b/rct229/rules/section6/section6rule2.py
@@ -6,11 +6,11 @@ from rct229.rule_engine.rule_base import (
 )
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 
-GUEST_ROOM = schema_enums["LightingSpaceType2019ASHRAE901TG37"].GUEST_ROOM.name
+GUEST_ROOM = schema_enums["LightingSpaceType2019ASHRAE901TG37"].GUEST_ROOM
 DORMITORY_LIVING_QUARTERS = schema_enums[
     "LightingSpaceType2019ASHRAE901TG37"
-].DORMITORY_LIVING_QUARTERS.name
-DWELLING_UNIT = schema_enums["LightingSpaceType2019ASHRAE901TG37"].DWELLING_UNIT.name
+].DORMITORY_LIVING_QUARTERS
+DWELLING_UNIT = schema_enums["LightingSpaceType2019ASHRAE901TG37"].DWELLING_UNIT
 
 
 class Section6Rule2(RuleDefinitionListIndexedBase):

--- a/rct229/rules/section6/section6rule3.py
+++ b/rct229/rules/section6/section6rule3.py
@@ -6,11 +6,11 @@ from rct229.rule_engine.rule_base import (
 )
 from rct229.rule_engine.user_baseline_proposed_vals import UserBaselineProposedVals
 
-GUEST_ROOM = schema_enums["LightingSpaceType2019ASHRAE901TG37"].GUEST_ROOM.name
+GUEST_ROOM = schema_enums["LightingSpaceType2019ASHRAE901TG37"].GUEST_ROOM
 DORMITORY_LIVING_QUARTERS = schema_enums[
     "LightingSpaceType2019ASHRAE901TG37"
-].DORMITORY_LIVING_QUARTERS.name
-DWELLING_UNIT = schema_enums["LightingSpaceType2019ASHRAE901TG37"].DWELLING_UNIT.name
+].DORMITORY_LIVING_QUARTERS
+DWELLING_UNIT = schema_enums["LightingSpaceType2019ASHRAE901TG37"].DWELLING_UNIT
 
 
 class Section6Rule3(RuleDefinitionListIndexedBase):

--- a/rct229/ruleset_functions/get_area_type_window_wall_area_dict.py
+++ b/rct229/ruleset_functions/get_area_type_window_wall_area_dict.py
@@ -11,7 +11,7 @@ from rct229.utils.assertions import getattr_
 from rct229.utils.jsonpath_utils import find_all
 from rct229.utils.pint_utils import ZERO
 
-DOOR = schema_enums["SubsurfaceClassificationType"].DOOR.name
+DOOR = schema_enums["SubsurfaceClassificationType"].DOOR
 
 
 def get_area_type_window_wall_area_dict(climate_zone, building):

--- a/rct229/ruleset_functions/get_building_scc_skylight_roof_ratios_dict.py
+++ b/rct229/ruleset_functions/get_building_scc_skylight_roof_ratios_dict.py
@@ -11,7 +11,7 @@ from rct229.utils.assertions import getattr_
 from rct229.utils.jsonpath_utils import find_all
 from rct229.utils.pint_utils import ZERO
 
-DOOR = schema_enums["SubsurfaceClassificationType"].DOOR.name
+DOOR = schema_enums["SubsurfaceClassificationType"].DOOR
 
 
 def get_building_scc_skylight_roof_ratios_dict(climate_zone, building):

--- a/rct229/ruleset_functions/get_building_scc_window_wall_ratios_dict.py
+++ b/rct229/ruleset_functions/get_building_scc_window_wall_ratios_dict.py
@@ -11,7 +11,7 @@ from rct229.utils.assertions import assert_required_fields, getattr_
 from rct229.utils.jsonpath_utils import find_all
 from rct229.utils.pint_utils import ZERO
 
-DOOR = schema_enums["SubsurfaceClassificationType"].DOOR.name
+DOOR = schema_enums["SubsurfaceClassificationType"].DOOR
 
 # Intended for internal use
 GET_BUILDING_SCC_WINDOW_WALL_RATIO_DICT__REQUIRED_FIELDS = {

--- a/rct229/ruleset_functions/get_building_segment_lighting_status_type_dict.py
+++ b/rct229/ruleset_functions/get_building_segment_lighting_status_type_dict.py
@@ -3,7 +3,7 @@ from rct229.data_fns.table_9_5_1_fns import table_9_5_1_lookup
 from rct229.utils.jsonpath_utils import find_all
 from rct229.utils.std_comparisons import std_equal
 
-NONE = schema_enums["LightingSpaceType2019ASHRAE901T951TG38"].NONE.name
+NONE = schema_enums["LightingSpaceType2019ASHRAE901T951TG38"].NONE
 
 # Intended for export and internal use
 class LightingStatusType:

--- a/rct229/ruleset_functions/get_surface_conditioning_category_dict.py
+++ b/rct229/ruleset_functions/get_surface_conditioning_category_dict.py
@@ -77,7 +77,7 @@ SCC_DATA_FRAME = pd.DataFrame(
             SurfaceConditioningCategory.UNREGULATED,
             SurfaceConditioningCategory.UNREGULATED,
         ],
-        SurfaceAdjacentTo.EXTERIOR.name: [
+        SurfaceAdjacentTo.EXTERIOR: [
             SurfaceConditioningCategory.EXTERIOR_RESIDENTIAL,
             SurfaceConditioningCategory.EXTERIOR_NON_RESIDENTIAL,
             SurfaceConditioningCategory.EXTERIOR_MIXED,
@@ -85,7 +85,7 @@ SCC_DATA_FRAME = pd.DataFrame(
             SurfaceConditioningCategory.UNREGULATED,
             SurfaceConditioningCategory.UNREGULATED,
         ],
-        SurfaceAdjacentTo.GROUND.name: [
+        SurfaceAdjacentTo.GROUND: [
             SurfaceConditioningCategory.EXTERIOR_RESIDENTIAL,
             SurfaceConditioningCategory.EXTERIOR_NON_RESIDENTIAL,
             SurfaceConditioningCategory.EXTERIOR_MIXED,
@@ -151,7 +151,7 @@ def get_surface_conditioning_category_dict(climate_zone, building):
                 zcc,
                 # column index
                 zcc_dict[getattr_(surface, "surface", "adjacent_zone")]
-                if surface_adjacent_to == SurfaceAdjacentTo.INTERIOR.name
+                if surface_adjacent_to == SurfaceAdjacentTo.INTERIOR
                 else surface_adjacent_to,
             ]
 

--- a/rct229/utils/jsonpath_utils.py
+++ b/rct229/utils/jsonpath_utils.py
@@ -28,19 +28,17 @@ def find_one_with_field_value(jpath, field, value, obj):
 
 def find_exactly_one_with_field_value(jpath, field, value, obj):
     matches = find_all_with_field_value(jpath, field, value, obj)
-    assert(
-        len(matches) == 1,
-        f"Search data referenced in {jpath} with key {value} returned multiple or None results",
-    )
+    assert (
+        len(matches) == 1
+    ), f"Search data referenced in {jpath} with key {value} returned multiple or None results"
 
     return matches[0]
 
 
 def find_exactly_one(jpath, obj):
     matches = find_all(jpath, obj)
-    assert(
-        len(matches) == 1,
-        f"Search data referenced in {jpath} returned multiple or None results",
-    )
+    assert (
+        len(matches) == 1
+    ), f"Search data referenced in {jpath} returned multiple or None results"
 
     return matches[0]


### PR DESCRIPTION
1. Model the enumerations with a class instead of Enum. This allows us to avoid the need to append `.name` to the enumeration when it is used.
2. Updated all the files that use the enumerations.
3. Removed unused imports of `schema_enum`.
4. Fixed `assert` syntax in `jasonpath_utils.py`.