### PR TITLE
RS/CH/unique-ids

### DIFF
--- a/rct229/data_fns/table_G3_7_fns_test.py
+++ b/rct229/data_fns/table_G3_7_fns_test.py
@@ -18,25 +18,19 @@ watts_per_sqft = ureg("watt / foot**2")
 
 # Testing table_G3_7_lookup() ----------------------------------------
 def test__table_G3_7_lookup__with_w_per_ft_null():
-    assert (
-        table_G3_7_lookup(
-            lighting_space_type="DORMITORY_LIVING_QUARTERS",
-            space_height=8 * feet,
-            space_area=16 * squarefeet,
-        )
-        == {"lpd": 1.11 * watts_per_sqft, "control_credit": 0.1}
-    )
+    assert table_G3_7_lookup(
+        lighting_space_type="DORMITORY_LIVING_QUARTERS",
+        space_height=8 * feet,
+        space_area=16 * squarefeet,
+    ) == {"lpd": 1.11 * watts_per_sqft, "control_credit": 0.1}
 
 
 def test__table_G3_7_lookup__with_w_per_ft_not_null():
-    assert (
-        table_G3_7_lookup(
-            lighting_space_type="ATRIUM_HIGH",
-            space_height=20 * feet,
-            space_area=16 * squarefeet,
-        )
-        == {"lpd": (0.5 + 0.025 * 20 / 16) * watts_per_sqft, "control_credit": 0.1}
-    )
+    assert table_G3_7_lookup(
+        lighting_space_type="ATRIUM_HIGH",
+        space_height=20 * feet,
+        space_area=16 * squarefeet,
+    ) == {"lpd": (0.5 + 0.025 * 20 / 16) * watts_per_sqft, "control_credit": 0.1}
 
 
 # Testing lighting_space_enumeration_to_lpd_space_type_map ----------

--- a/rct229/schema/validate.py
+++ b/rct229/schema/validate.py
@@ -1,5 +1,6 @@
 import json
 import os
+
 import jsonschema
 
 from rct229.utils.jsonpath_utils import find_all

--- a/rct229/schema/validate.py
+++ b/rct229/schema/validate.py
@@ -1,7 +1,8 @@
 import json
 import os
-
 import jsonschema
+
+from rct229.utils.jsonpath_utils import find_all
 
 file_dir = os.path.dirname(__file__)
 
@@ -11,6 +12,143 @@ SCHEMA_RESNET_ENUM_KEY = "EnumerationsRESNET.schema.json"
 SCHEMA_PATH = os.path.join(file_dir, SCHEMA_KEY)
 SCHEMA_ENUM_PATH = os.path.join(file_dir, SCHEMA_ENUM_KEY)
 SCHEMA_RESNET_ENUM_PATH = os.path.join(file_dir, SCHEMA_RESNET_ENUM_KEY)
+
+
+def check_unique_ids_in_ruleset_model_instances(rmd):
+    """Checks that the ids within each group inside a
+    RuleSetModelInstance are unique
+
+    The strategy is to first find all unique json paths to all lists inside the
+    RuleSetModelInstance, with all list indexes set to [*]. For example,
+    the general jsonpath to the building_segments is "buildings[*].building_segments".
+    Then, for each of these unique list_paths, we use find_all using the jsonpath
+    list_path[*].id to find all the ids for this path and check that they are unique.
+
+    Parameters
+    ----------
+    rmd : dict
+        A dictionary representing an RMD
+
+    Returns
+    -------
+    str
+        An error message listing any paths that do not have unique ids. The empty string
+        indicates that all appropriate ids are unique.
+    """
+    # The schema does not require the ruleset_model_instances field, default to []
+    ruleset_model_instances = rmd.get("ruleset_model_instances", [])
+
+    bad_paths = []
+    for rmi_index, rmi in enumerate(ruleset_model_instances):
+        # Collect all jsonpaths to lists
+        paths = json_paths_to_lists(rmi)
+
+        for list_path in paths:
+            ids = find_all(list_path + "[*].id", rmi)
+            if len(ids) != len(set(ids)):
+                # The ids are not unique
+                # list_path starts with "$" that must be removed
+                bad_path = f"ruleset_model_instances[{rmi_index}]{list_path[1:]}"
+                bad_paths.append(bad_path)
+
+    error_msg = f"Non-unique ids for paths: {'; '.join(bad_paths)}" if bad_paths else ""
+
+    return error_msg
+
+
+# json_paths_to_lists, json_paths_to_lists_from_dict, and json_paths_to_lists_from_list
+# work together
+
+
+def json_paths_to_lists(val, path="$"):
+    """Determines all the generic json paths to lists inside an object
+
+    If a json path has a list index, that index is replaced with [*] to make it
+    generic.
+
+    Parameters
+    ----------
+    val : any
+        Only dict and list objects are processed, all others are ignored
+    path : str
+        A json path representing a generic path to val in a larger structure
+
+    Returns
+    -------
+    set
+        A set of unique generic json paths to lists inside val
+    """
+    paths = set()
+    if isinstance(val, dict):
+        paths = json_paths_to_lists_from_dict(val, path)
+    elif isinstance(val, list):
+        paths = json_paths_to_lists_from_list(val, path)
+
+    return paths
+
+
+def json_paths_to_lists_from_dict(rmd_dict, path):
+    """Determines all the generic json paths to lists inside an dictionary
+
+    If a json path has a list index, that index is replaced with [*] to make it
+    generic.
+
+    Parameters
+    ----------
+    rmd_dict : dict
+
+    path : str
+        A json path representing a generic path to rmd_dict in a larger structure
+
+    Returns
+    -------
+    set
+        A set of unique generic json paths to lists inside rmd_dict
+    """
+    paths = set()
+    for (key, val) in rmd_dict.items():
+        new_path = f"{path}.{key}"
+        new_paths = json_paths_to_lists(val, new_path)
+        paths = paths.union(new_paths)
+
+    return paths
+
+
+def json_paths_to_lists_from_list(rmd_list, path):
+    """Determines all the generic json paths to lists inside a list
+
+    If a json path has a list index, that index is replaced with [*] to make it
+    generic.
+
+    Parameters
+    ----------
+    rmd_list : dict
+
+    path : str
+        A json path representing a generic path to rmd_list in a larger structure
+
+    Returns
+    -------
+    set
+        A set of unique generic json paths to lists inside rmd_list
+    """
+    paths = {path}
+    for val in rmd_list:
+        new_path = f"{path}[*]"
+        new_paths = json_paths_to_lists(val, new_path)
+        paths = paths.union(new_paths)
+
+    return paths
+
+
+def non_schema_validate_rmr(rmr_obj):
+    """Provides non-schema validation for an RMR"""
+
+    unique_id_error = check_unique_ids_in_ruleset_model_instances(rmr_obj)
+    passed = not unique_id_error
+    error = unique_id_error or None
+
+    return {"passed": passed, "error": error}
 
 
 def schema_validate_rmr(rmr_obj):
@@ -46,15 +184,6 @@ def schema_validate_rmr(rmr_obj):
         return {"passed": True, "error": None}
     except jsonschema.exceptions.ValidationError as err:
         return {"passed": False, "error": "schema invalid: " + err.message}
-
-
-def non_schema_validate_rmr(rmr_obj):
-    """Provides non-schema validation for an RMR"""
-    # TODO: Add checks for:
-    # The ids within each Group are unique
-    # A Subsurface must have exactly one of glazed_area or opaque_area
-    #
-    return {"passed": True, "error": None}
 
 
 def validate_rmr(rmr_obj):

--- a/rct229/schema/validate_test.py
+++ b/rct229/schema/validate_test.py
@@ -1,6 +1,7 @@
-from copy import deepcopy
 import json
 import os
+from copy import deepcopy
+
 import pytest
 
 from rct229.schema.validate import (

--- a/rct229/schema/validate_test.py
+++ b/rct229/schema/validate_test.py
@@ -1,9 +1,16 @@
+from copy import deepcopy
 import json
 import os
-
 import pytest
 
-from rct229.schema.validate import validate_rmr
+from rct229.schema.validate import (
+    check_unique_ids_in_ruleset_model_instances,
+    json_paths_to_lists,
+    json_paths_to_lists_from_dict,
+    json_paths_to_lists_from_list,
+    non_schema_validate_rmr,
+    validate_rmr,
+)
 
 EXAMPLES_PATH = "examples"
 
@@ -27,3 +34,93 @@ def test__validate_rmr__with_user_rmr():
     with open(os.path.join(EXAMPLES_PATH, "user_rmr.json")) as rmr_file:
         rmr_obj = json.load(rmr_file)
     assert validate_rmr(rmr_obj) == {"passed": True, "error": None}
+
+
+## Testing the three companion functions that find json paths to list
+
+TEST_IDS_RMD = {
+    "ruleset_model_instances": [
+        {
+            "id": "rmi_1",
+            "buildings": [
+                {
+                    "id": "bldg_1_1",
+                    "building_segments": [
+                        {"id": "bs_1_1_1"},
+                        {"id": "bs_1_1_2"},
+                    ],
+                },
+                {
+                    "id": "bldg_1_2",
+                    "building_segments": [
+                        {"id": "bs_1_2_1"},
+                        # A duplicate
+                        {"id": "bs_1_1_2"},
+                    ],
+                },
+            ],
+        }
+    ]
+}
+
+TEST_UNIQUE_IDS_RMD = deepcopy(TEST_IDS_RMD)
+TEST_UNIQUE_IDS_RMD["ruleset_model_instances"][0]["buildings"][1]["building_segments"][
+    1
+]["id"] = "bs_1_2_2"
+
+
+def test__json_paths_to_lists_from_dict():
+    assert json_paths_to_lists_from_dict(TEST_IDS_RMD, "$") == {
+        "$.ruleset_model_instances",
+        "$.ruleset_model_instances[*].buildings",
+        "$.ruleset_model_instances[*].buildings[*].building_segments",
+    }
+
+
+def test__json_paths_to_lists_from_list():
+    assert json_paths_to_lists_from_list(
+        TEST_IDS_RMD["ruleset_model_instances"], "$.ruleset_model_instances"
+    ) == {
+        "$.ruleset_model_instances",
+        "$.ruleset_model_instances[*].buildings",
+        "$.ruleset_model_instances[*].buildings[*].building_segments",
+    }
+
+
+def test__json_paths_to_lists():
+    assert json_paths_to_lists(TEST_IDS_RMD) == {
+        "$.ruleset_model_instances",
+        "$.ruleset_model_instances[*].buildings",
+        "$.ruleset_model_instances[*].buildings[*].building_segments",
+    }
+
+
+# -----------------------------------------------
+
+
+def test__check_unique_ids_in_ruleset_model_instances__not_unique():
+    assert (
+        check_unique_ids_in_ruleset_model_instances(TEST_IDS_RMD)
+        == "Non-unique ids for paths: ruleset_model_instances[0].buildings[*].building_segments"
+    )
+
+
+def test__check_unique_ids_in_ruleset_model_instances__unique():
+    assert check_unique_ids_in_ruleset_model_instances(TEST_UNIQUE_IDS_RMD) == ""
+
+
+# -----------------------------------------------
+
+
+def test__non_schema_validate_rmr__not_unique():
+    assert non_schema_validate_rmr(TEST_IDS_RMD) == {
+        "passed": False,
+        "error": "Non-unique ids for paths: ruleset_model_instances[0].buildings[*].building_segments",
+    }
+
+
+def test__non_schema_validate_rmr__unique():
+    assert non_schema_validate_rmr(TEST_UNIQUE_IDS_RMD) == {
+        "passed": True,
+        "error": None,
+    }

--- a/rct229/utils/match_lists_test.py
+++ b/rct229/utils/match_lists_test.py
@@ -4,33 +4,24 @@ from match_lists import match_lists
 
 # Testing match_lists()
 def test__match_lists__with_matching_lists():
-    assert (
-        match_lists(
-            [{"name": "A"}, {"name": "B"}, {"name": "C"}],
-            [{"name": "B"}, {"name": "A"}, {"name": "C"}],
-            "/name",
-        )
-        == [{"name": "A"}, {"name": "B"}, {"name": "C"}]
-    )
+    assert match_lists(
+        [{"name": "A"}, {"name": "B"}, {"name": "C"}],
+        [{"name": "B"}, {"name": "A"}, {"name": "C"}],
+        "/name",
+    ) == [{"name": "A"}, {"name": "B"}, {"name": "C"}]
 
 
 def test__match_lists__with_nonmatching_lists_1():
-    assert (
-        match_lists(
-            [{"name": "A"}, {"name": "B", "num": 8}, {"name": "C"}],
-            [{"name": "H"}, {"name": "A"}],
-            "/name",
-        )
-        == [{"name": "A"}, None, None]
-    )
+    assert match_lists(
+        [{"name": "A"}, {"name": "B", "num": 8}, {"name": "C"}],
+        [{"name": "H"}, {"name": "A"}],
+        "/name",
+    ) == [{"name": "A"}, None, None]
 
 
 def test__match_lists__with_nonmatching_lists_2():
-    assert (
-        match_lists(
-            [{"name": "H"}, {"name": "A"}],
-            [{"name": "A"}, {"name": "B", "num": 8}, {"name": "C"}],
-            "/name",
-        )
-        == [None, {"name": "A"}]
-    )
+    assert match_lists(
+        [{"name": "H"}, {"name": "A"}],
+        [{"name": "A"}, {"name": "B", "num": 8}, {"name": "C"}],
+        "/name",
+    ) == [None, {"name": "A"}]


### PR DESCRIPTION
This adds a check for unique id values immediately after schema validation.

The strategy is to first determine "generic" json paths to all the lists inside a RuleSetModelInstance.  An example of such a path would be `"buildings[*].building_segments[*].zones"`.

Then we use _find_all_ to collect all the ids in these lists, as with 
```
find_all("buildings[*].building_segments[*].zones[*].id", <a RuleSetModelInstance>)
```

Finally, we check that this list of ids has no duplicates.