### PR TITLE
add error handling

### DIFF
--- a/rct229/ruleset_functions/get_baseline_system_types.py
+++ b/rct229/ruleset_functions/get_baseline_system_types.py
@@ -89,22 +89,18 @@ def get_baseline_system_types(rmi_b):
                 continue
 
             # Add error handling
-            # no matching system warning
-            iterator = iter(
+            hvac_sys_count = len(
                 [
-                    hvac_b_id in baseline_hvac_system_dict[hvac_sys_key]
+                    hvac_b_id
                     for hvac_sys_key in baseline_hvac_system_dict.keys()
+                    if hvac_b_id in baseline_hvac_system_dict[hvac_sys_key]
                 ]
             )
-            # consume from index 0 until first true or it's exhausted
-            at_least_one_hvac_sys = any(iterator)
-            # carry on consuming until another true value / exhausted
-            multiple_hvac_sys = any(iterator)
-            if not at_least_one_hvac_sys:
+            if hvac_sys_count == 0:
                 raise RCTFailureException(
                     f"Error: HVAC {hvac_b_id} does not match any baseline system type."
                 )
-            if multiple_hvac_sys:
+            elif hvac_sys_count > 1:
                 raise RCTFailureException(
                     f"Error: HVAC {hvac_b_id} matches to multiple baseline system types - check your RMD models"
                 )

--- a/rct229/ruleset_functions/get_baseline_system_types.py
+++ b/rct229/ruleset_functions/get_baseline_system_types.py
@@ -16,6 +16,7 @@ from rct229.ruleset_functions.baseline_systems.is_baseline_system_11_2 import (
 from rct229.ruleset_functions.get_dict_of_zones_and_terminal_units_served_by_hvac_sys import (
     get_dict_of_zones_and_terminal_units_served_by_hvac_sys,
 )
+from rct229.utils.assertions import RCTFailureException
 from rct229.utils.jsonpath_utils import find_all
 
 
@@ -86,5 +87,17 @@ def get_baseline_system_types(rmi_b):
             if hvac_sys != HVAC_SYS.UNMATCHED:
                 baseline_hvac_system_dict[hvac_sys].append(hvac_b_id)
                 continue
+
+            # Add error handling
+            # no matching system warning
+            iterator = iter([hvac_b_id in baseline_hvac_system_dict[hvac_sys_key] for hvac_sys_key in baseline_hvac_system_dict.keys()])
+            # consume from index 0 until first true or it's exhausted
+            at_least_one_hvac_sys = any(iterator)
+            # carry on consuming until another true value / exhausted
+            multiple_hvac_sys = any(iterator)
+            if not at_least_one_hvac_sys:
+                raise RCTFailureException(f"Error: HVAC {hvac_b_id} does not match any baseline system type.")
+            if multiple_hvac_sys:
+                raise RCTFailureException(f"Error: HVAC {hvac_b_id} matches to multiple baseline system types - check your RMD models")
 
     return baseline_hvac_system_dict

--- a/rct229/ruleset_functions/get_baseline_system_types.py
+++ b/rct229/ruleset_functions/get_baseline_system_types.py
@@ -90,14 +90,23 @@ def get_baseline_system_types(rmi_b):
 
             # Add error handling
             # no matching system warning
-            iterator = iter([hvac_b_id in baseline_hvac_system_dict[hvac_sys_key] for hvac_sys_key in baseline_hvac_system_dict.keys()])
+            iterator = iter(
+                [
+                    hvac_b_id in baseline_hvac_system_dict[hvac_sys_key]
+                    for hvac_sys_key in baseline_hvac_system_dict.keys()
+                ]
+            )
             # consume from index 0 until first true or it's exhausted
             at_least_one_hvac_sys = any(iterator)
             # carry on consuming until another true value / exhausted
             multiple_hvac_sys = any(iterator)
             if not at_least_one_hvac_sys:
-                raise RCTFailureException(f"Error: HVAC {hvac_b_id} does not match any baseline system type.")
+                raise RCTFailureException(
+                    f"Error: HVAC {hvac_b_id} does not match any baseline system type."
+                )
             if multiple_hvac_sys:
-                raise RCTFailureException(f"Error: HVAC {hvac_b_id} matches to multiple baseline system types - check your RMD models")
+                raise RCTFailureException(
+                    f"Error: HVAC {hvac_b_id} matches to multiple baseline system types - check your RMD models"
+                )
 
     return baseline_hvac_system_dict


### PR DESCRIPTION
Handle issues
1. When HVAC system do not match any baseline system types (model error since it is baseline system only)
2. When HVAC system matches multiple baseline system types (model error or RCT bug.. will need to think how to handle the RCT bug)