### PR TITLE
TEMPORARY 0018 SCHEMA UPDATE

### DIFF
--- a/rct229/ruletest_engine/ruletest_jsons/scripts/resources/json_pointer_enumerations.json
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/resources/json_pointer_enumerations.json
@@ -17,6 +17,7 @@
 	"infiltration": "ruleset_model_instances[0]/buildings[0]/building_segments[0]/zones[0]/infiltration",
 	"interior_lighting": "ruleset_model_instances[0]/buildings[0]/building_segments[0]/zones[0]/spaces[0]/interior_lighting",
 	"miscellaneous_equipment": "ruleset_model_instances[0]/buildings[0]/building_segments[0]/zones[0]/spaces[0]/miscellaneous_equipment",
+	"output": "ruleset_model_instances[0]/output",
 	"preheat_system": "ruleset_model_instances[0]/buildings[0]/building_segments[0]/heating_ventilation_air_conditioning_systems[0]/preheat_system",
 	"pumps": "ruleset_model_instances[0]/pumps",
 	"sensible_cool_capacity": "ruleset_model_instances[0]/buildings[0]/building_segments[0]/heating_ventilation_air_conditioning_systems[0]/cooling_system/sensible_cool_capacity",

--- a/rct229/schema/ASHRAE229.schema.json
+++ b/rct229/schema/ASHRAE229.schema.json
@@ -185,6 +185,13 @@
                 "site_zone_type": {
                     "description": "Site zone type for Sec 9.4.2",
                     "$ref": "Enumerations2019ASHRAE901.schema.json#/definitions/ExteriorLightingZoneOptions2019ASHRAE901"
+                },
+				"output": {
+                    "description": "Output",
+                    "items":
+                        {
+                            "$ref": "ASHRAE229.schema.json#/definitions/Output2019ASHRAE901"
+                        }
                 }
             },
             "required": [
@@ -4703,6 +4710,154 @@
                 "-26.1 C +/- 1.1 C (-15 F +/- 2 F). This corresponds to the ice cream category in AHRI 1200",
                 null
             ]
+        },
+		"Output2019ASHRAE901": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Scope-unique reference identifier for instances of this data group.",
+                    "type": "string"
+                },
+                "reporting_name": {
+                    "description": "Descriptive name used in RCT reports if id is not already a descriptive name",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Supplementary information to provide context to the model reviewer",
+                    "type": "string"
+                },
+                "output_instance": {
+                    "description": "References output that correspond to specific simulation model.",
+                    "$ref": "Output2019ASHRAE901.schema.json#/definitions/OutputInstance",
+                    "notes": "A seperate file is expected for each simulation model including outputs that correspond with building rotations."
+                },
+                "performance_cost_index": {
+                    "description": "Performance cost index for the project",
+                    "type": "number",
+                    "notes": "This output is appropriate for the overall project not specific instance of a model."
+                },
+                "baseline_building_unregulated_energy_cost": {
+                    "description": "baseline building unregulated energy cost.",
+                    "type": "number",
+                    "notes": "The units are the local monetary units such as dollars. This output is appropriate for the overall project not specific instance of a model."
+                },
+                "baseline_building_regulated_energy_cost": {
+                    "description": "baseline building regulated energy cost.",
+                    "type": "number",
+                    "notes": "The units are the local monetary units such as dollars. This output is appropriate for the overall project not specific instance of a model."
+                },
+                "baseline_building_performance_energy_cost": {
+                    "description": "baseline building performance energy cost.",
+                    "type": "number",
+                    "notes": "The units are the local monetary units such as dollars. This output is appropriate for the overall project not specific instance of a model."
+                },
+                "total_area_weighted_building_performance_factor": {
+                    "description": "Total area weighted building performance factor",
+                    "type": "number",
+                    "notes": "This output is appropriate for the overall project not specific instance of a model."
+                },
+                "performance_cost_index_target": {
+                    "description": "Performance cost index target for the project",
+                    "type": "number",
+                    "notes": "This output is appropriate for the overall project not specific instance of a model."
+                },
+                "total_proposed_building_energy_cost_including_renewable_energy": {
+                    "description": "Total proposed building energy cost including renewable energy.",
+                    "type": "number",
+                    "notes": "The units are the local monetary units such as dollars. This output is appropriate for the overall project not specific instance of a model."
+                },
+                "total_proposed_building_energy_cost_excluding_renewable_energy": {
+                    "description": "Total proposed building energy cost excluding renewable energy.",
+                    "type": "number",
+                    "notes": "The units are the local monetary units such as dollars. This output is appropriate for the overall project not specific instance of a model."
+                },
+                "percent_renewable_energy_savings": {
+                    "description": "Percent renewable energy savings",
+                    "type": "number",
+                    "notes": "This output is appropriate for the overall project not specific instance of a model."
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "additionalProperties": false
+        },
+		"OutputInstance": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "Scope-unique reference identifier for instances of this data group.",
+                    "type": "string"
+                },
+                "reporting_name": {
+                    "description": "Descriptive name used in RCT reports if id is not already a descriptive name",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Supplementary information to provide context to the model reviewer",
+                    "type": "string"
+                },
+                "ruleset_model_type": {
+                    "description": "Describes the current model instance for rulesets with multiple simulation models"
+                },
+                "rotation_angle": {
+                    "description": "Rotation angle of the building model.",
+                    "type": "number",
+                    "minimum": 0.0,
+                    "exclusiveMaximum": 360.0,
+                    "notes": "Usually 0, 90, 180, or 270."
+                },
+                "unmet_load_hours_heating": {
+                    "description": "Unmet load hours for heating",
+                    "type": "number",
+                    "units": "hr"
+                },
+                "unmet_occupied_load_hours_heating": {
+                    "description": "Unmet load hours for heating when the zone is occupied",
+                    "type": "number",
+                    "units": "hr"
+                },
+                "unmet_load_hours_cooling": {
+                    "description": "Unmet load hours for cooling",
+                    "type": "number",
+                    "units": "hr"
+                },
+                "unmet_occupied_load_hours_cooling": {
+                    "description": "Unmet load hours for cooling when the zone is occupied",
+                    "type": "number",
+                    "units": "hr"
+                },
+                "annual_source_results": {
+                    "description": "Annual results by source",
+                    "type": "array",
+                    "items": {
+                        "$ref": "Output2019ASHRAE901.schema.json#/definitions/SourceResult"
+                    },
+                    "notes": "Contains a list of results by energy source."
+                },
+                "building_peak_cooling_load": {
+                    "description": "Building peak cooling load",
+                    "type": "number",
+                    "units": "W"
+                },
+                "annual_end_use_results": {
+                    "description": "Annual end use results",
+                    "type": "array",
+                    "items": {
+                        "$ref": "Output2019ASHRAE901.schema.json#/definitions/EndUseResult"
+                    },
+                    "notes": "Contains a list of results by end use and energy source."
+                }
+            },
+            "required": [
+                "id",
+                "unmet_load_hours_heating",
+                "unmet_occupied_load_hours_heating",
+                "unmet_load_hours_cooling",
+                "unmet_occupied_load_hours_cooling",
+                "building_peak_cooling_load"
+            ],
+            "additionalProperties": false
         }
     },
     "version": "0.0.18",


### PR DESCRIPTION
This PR addresses the temporary 0.0.18 schema update. Now, the schema has the ```output``` key. 

@jugonzal07 and I plan to update the ```excel_to_test_json.py``` to be able to handle the external reference around December.