### PR TITLE
RS+RT/YJ/RULE 22-14 (Small Fix)

### DIFF
--- a/rct229/rules/section22/section22rule14.py
+++ b/rct229/rules/section22/section22rule14.py
@@ -19,7 +19,7 @@ APPLICABLE_SYS_TYPES = [
     HVAC_SYS.SYS_11_1B,
     HVAC_SYS.SYS_12B,
 ]
-REQUIRED_TEMP_RANGE = ureg("10 degF")
+REQUIRED_TEMP_RANGE = 10 * ureg("degR")
 
 
 class Section22Rule14(RuleDefinitionListIndexedBase):

--- a/rct229/ruletest_engine/ruletest_jsons/section22/rule_22_14.json
+++ b/rct229/ruletest_engine/ruletest_jsons/section22/rule_22_14.json
@@ -138,7 +138,7 @@
                             {
                                 "id": "Heat Rejection 1",
                                 "loop": "Chiller Loop 1",
-                                "range": -12.222222222222172
+                                "range": 5.555555555555555
                             }
                         ]
                     }
@@ -285,7 +285,7 @@
                             {
                                 "id": "Heat Rejection 1",
                                 "loop": "Chiller Loop 1",
-                                "range": -9.4444444444444
+                                "range": 8.333333333333334
                             }
                         ]
                     }


### PR DESCRIPTION
This PR addresses
1) 22-14 RMD updates. The```range``` temperature part updates weren't reflected in the 22-14 JSON file after it was updated in the schema.
2) ```REQUIRED_TEMP_RANGE```'s unit was changed to ```deg R``` from ```deg F```.