### PR TITLE
RS/YJ/is baseline system 6 and 8

### DIFF
--- a/docs/ruleset_functions/baseline_systems/is_baseline_system_6.md
+++ b/docs/ruleset_functions/baseline_systems/is_baseline_system_6.md
@@ -10,8 +10,8 @@
 
 **Returns:**  
 - **is_baseline_system_6**: The function returns either Sys-6, Sys-6b, or Not_Sys_6 string output which indicates whether the HVAC system is ASHRAE 90.1 2019 Appendix G system 6 (Package VAV with PFP Boxes) or system 6b (system 6 with purchased heating).   
- 
-**Function Call:** 
+
+**Function Call:**
 1. does_each_zone_have_only_one_terminal()     
 3. is_hvac_sys_cooling_type_DX()
 4. is_hvac_sys_fan_sys_VSD()  
@@ -22,16 +22,15 @@
 9. are_all_terminal_heating_loops_purchased_heating()
 10. are_all_terminal_heat_sources_electric()
 11. are_all_terminal_fan_configs_parallel()
-12. do_all_terminals_have_one_fan() 
+12. do_all_terminals_have_one_fan()
 13. are_all_terminal_cool_sources_none_or_null() 
 14. are_all_terminal_types_VAV()  
-15. is_there_only_one_hvac_sys_cooling_system ()  
 
 
 ## Logic:    
 - Create an object associated with the hvac system: `hvac_b = hvac_b.id`  
 - Set is_baseline_system_6 = Not_Sys_6: `is_baseline_system_6 = "Not_Sys_6"`    
-- Check that there is no heating system, if there is none then carry on: `if len(hvac_b.heating_system) == Null or hvac_b.heating_system.heating_system_type == "NONE":` 
+- Check that there is no heating system, if there is none then carry on: `if len(hvac_b.heating_system) == Null or hvac_b.heating_system.heating_system_type == "NONE":`
 - Check that there is one preheat system per G3.1.3.19, if there is then carry on: `if Len(hvac_b.preheat_system) == 1:`   
     - Check that there is a cooling system: `if hvac_b.cooling_system != Null or hvac_b.cooling_system.cooling_system_type != "NONE":`  
         - Check if the cooling system type is DX, if yes then carry on: `if is_hvac_sys_cooling_type_DX(B_RMR, hvac_b.id) == TRUE:`  
@@ -46,7 +45,7 @@
 **Returns** `is_baseline_system_6`  
 
 **Notes**  
-1. In the current graphical depiction it has electric reheat for when there is purchased heating at the HVAC system level but based on G3.1.1.3.1 it appears that all heating coils should be purchased heating when there is purchased heating in the building providing space heating.  If others disagree I can of course modify this but just wanted to highlight the assumption used in the logic above. 
+1. In the current graphical depiction it has electric reheat for when there is purchased heating at the HVAC system level but based on G3.1.1.3.1 it appears that all heating coils should be purchased heating when there is purchased heating in the building providing space heating.  If others disagree I can of course modify this but just wanted to highlight the assumption used in the logic above.
 
 
 **[Back](../../_toc.md)**

--- a/docs/ruleset_functions/baseline_systems/is_baseline_system_8.md
+++ b/docs/ruleset_functions/baseline_systems/is_baseline_system_8.md
@@ -10,8 +10,8 @@
 
 **Returns:**  
 - **is_baseline_system_8**: The function returns either Sys-8, Sys-8a, Sys-8b, Sys-8c, or Not_Sys_8 string output which indicates whether the HVAC system is ASHRAE 90.1 2019 Appendix G system 8 (VAV with Parallel Fan-Powered Boxes and Reheat ), system 8a (system 8 with purchased CHW), system 8b (system 8 with purchased heating), or 8c (system 8 with purchased heating and purchased chilled water).   
- 
-**Function Call:** 
+
+**Function Call:**
 1. does_each_zone_have_only_one_terminal()    
 3. is_hvac_sys_cooling_type_fluid_loop()  
 4. is_hvac_sys_fluid_loop_purchased_CHW()
@@ -24,10 +24,9 @@
 11. are_all_terminal_heating_loops_purchased_heating()
 12. are_all_terminal_heat_sources_electric()
 13. are_all_terminal_fan_configs_parallel()
-14. do_all_terminals_have_one_fan() 
-15. are_all_terminal_cool_sources_none_or_null() 
+14. do_all_terminals_have_one_fan()
+15. are_all_terminal_cool_sources_none_or_null()
 16. are_all_terminal_types_VAV()  
-17. is_there_only_one_hvac_sys_cooling_system ()  
 
 
 ## Logic:    
@@ -35,23 +34,22 @@
 - Set is_baseline_system_8 = Not_Sys_8: `is_baseline_system_8 = "Not_Sys_8"`    
 - Check that there is no heating system, if there is none then carry on: `if len(hvac_b.heating_system) == Null or hvac_b.heating_system[0].heating_system_type == "NONE":`  
     - Check that there is one preheat system per G3.1.3.19, if there is then carry on: `if Len(hvac_b.preheat_system) == 1:`   
-        - Check that there is only one cooling system: `if is_there_only_one_hvac_sys_cooling_system (B_RMR, hvac_b.id) == TRUE:` 
-            - Check if the cooling system type is a fluid loop, if yes then carry on: `if is_hvac_sys_cooling_type_fluid_loop(B_RMR, hvac_b.id) == TRUE:`  
-                - Check if fansystem is variable speed drive controlled, if yes then carry on: `if is_hvac_sys_fan_sys_VSD(B_RMR, hvac_b.id) == TRUE:`  
-                    - Check that each zone only has one terminal unit: `if does_each_zone_have_only_one_terminal(B_RMR,zone_id_list) == TRUE:`     
-                        - Check that the data elements associated with the terminal units align with system 8: `if are_all_terminal_cool_sources_none_or_null(B_RMR,terminal_unit_id_list) == TRUE And do_all_terminals_have_one_fan(B_RMR,terminal_unit_id_list) == TRUE AND are_all_terminal_types_VAV(B_RMR,terminal_unit_id_list) == TRUE AND are_all_terminal_fan_configs_parallel(B_RMR,terminal_unit_id_list) == TRUE:`        
-                            - if the hvac sys preheat loop is electric resistance, the terminal units have electric reheat, and the hvac sys cooling loop is attached to a chiller then Sys-8: `if is_hvac_sys_preheating_type_elec_resistance(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_electric(B_RMR,terminal_unit_id_list) == TRUE is_hvac_sys_fluid_loop_attached_to_chiller(B_RMR, hvac_b.id) == TRUE: is_baseline_system_8 = "Sys-8"`
-                            - elif the hvac sys preheat loop is electric resistance, the terminal units have electric reheat, and the hvac sys cooling loop is purchased CHW then Sys-8a: `elif is_hvac_sys_preheating_type_elec_resistance(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_electric(B_RMR,terminal_unit_id_list) == TRUE AND is_hvac_sys_fluid_loop_purchased_CHW(B_RMR, hvac_b.id) == TRUE: is_baseline_system_8 = "Sys-8a"` 
-                            - elif the preheat loop is a fluid loop: `elif is_hvac_sys_preheating_type_fluid_loop(B_RMR, hvac_b.id) == TRUE:`  
-                                - If preheat loop is purchased heating, all terminal unit heating is hot_water, and the hvac sys cooling loop is attached to a chiller: `If is_hvac_sys_preheat_fluid_loop_purchased_heating(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_hot_water(B_RMR,terminal_unit_id_list) == TRUE AND is_hvac_sys_fluid_loop_attached_to_chiller(B_RMR, hvac_b.id) == TRUE:`  
-                                    - If all terminal hot water loops are purchased heating then Sys-8b: `if are_all_terminal_heating_loops_purchased_heating(B_RMR,terminal_unit_id_list) == TRUE: is_baseline_system_8 = "Sys-8b"`
-                                - elif preheat loop is purchased heating, all terminal unit heating is hot_water, and the hvac sys cooling loop is purchased chilled water: `If is_hvac_sys_preheat_fluid_loop_purchased_heating(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_hot_water(B_RMR,terminal_unit_id_list) == TRUE AND is_hvac_sys_fluid_loop_purchased_CHW(B_RMR, hvac_b.id) == TRUE:`  
-                                    - If all terminal hot water loops are purchased heating then Sys-8c: `if are_all_terminal_heating_loops_purchased_heating(B_RMR,terminal_unit_id_list) == TRUE: is_baseline_system_8 = "Sys-8c"`
+          - Check if the cooling system type is a fluid loop, if yes then carry on: `if is_hvac_sys_cooling_type_fluid_loop(B_RMR, hvac_b.id) == TRUE:`  
+              - Check if fansystem is variable speed drive controlled, if yes then carry on: `if is_hvac_sys_fan_sys_VSD(B_RMR, hvac_b.id) == TRUE:`  
+                  - Check that each zone only has one terminal unit: `if does_each_zone_have_only_one_terminal(B_RMR,zone_id_list) == TRUE:`     
+                      - Check that the data elements associated with the terminal units align with system 8: `if are_all_terminal_cool_sources_none_or_null(B_RMR,terminal_unit_id_list) == TRUE And do_all_terminals_have_one_fan(B_RMR,terminal_unit_id_list) == TRUE AND are_all_terminal_types_VAV(B_RMR,terminal_unit_id_list) == TRUE AND are_all_terminal_fan_configs_parallel(B_RMR,terminal_unit_id_list) == TRUE:`        
+                          - if the hvac sys preheat loop is electric resistance, the terminal units have electric reheat, and the hvac sys cooling loop is attached to a chiller then Sys-8: `if is_hvac_sys_preheating_type_elec_resistance(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_electric(B_RMR,terminal_unit_id_list) == TRUE is_hvac_sys_fluid_loop_attached_to_chiller(B_RMR, hvac_b.id) == TRUE: is_baseline_system_8 = "Sys-8"`
+                          - elif the hvac sys preheat loop is electric resistance, the terminal units have electric reheat, and the hvac sys cooling loop is purchased CHW then Sys-8a: `elif is_hvac_sys_preheating_type_elec_resistance(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_electric(B_RMR,terminal_unit_id_list) == TRUE AND is_hvac_sys_fluid_loop_purchased_CHW(B_RMR, hvac_b.id) == TRUE: is_baseline_system_8 = "Sys-8a"`
+                          - elif the preheat loop is a fluid loop: `elif is_hvac_sys_preheating_type_fluid_loop(B_RMR, hvac_b.id) == TRUE:`  
+                              - If preheat loop is purchased heating, all terminal unit heating is hot_water, and the hvac sys cooling loop is attached to a chiller: `If is_hvac_sys_preheat_fluid_loop_purchased_heating(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_hot_water(B_RMR,terminal_unit_id_list) == TRUE AND is_hvac_sys_fluid_loop_attached_to_chiller(B_RMR, hvac_b.id) == TRUE:`  
+                                  - If all terminal hot water loops are purchased heating then Sys-8b: `if are_all_terminal_heating_loops_purchased_heating(B_RMR,terminal_unit_id_list) == TRUE: is_baseline_system_8 = "Sys-8b"`
+                              - elif preheat loop is purchased heating, all terminal unit heating is hot_water, and the hvac sys cooling loop is purchased chilled water: `If is_hvac_sys_preheat_fluid_loop_purchased_heating(B_RMR, hvac_b.id) == TRUE AND are_all_terminal_heat_sources_hot_water(B_RMR,terminal_unit_id_list) == TRUE AND is_hvac_sys_fluid_loop_purchased_CHW(B_RMR, hvac_b.id) == TRUE:`  
+                                  - If all terminal hot water loops are purchased heating then Sys-8c: `if are_all_terminal_heating_loops_purchased_heating(B_RMR,terminal_unit_id_list) == TRUE: is_baseline_system_8 = "Sys-8c"`
 
 **Returns** `is_baseline_system_8`  
 
 **Notes**  
-1. In the current graphical depiction it has electric reheat for when there is purchased heating at the HVAC system level but based on G3.1.1.3.1 it appears that all heating coils should be purchased heating when there is purchased heating in the building providing space heating.  If others disagree I can of course modify this but just wanted to highlight the assumption used in the logic above. 
+1. In the current graphical depiction it has electric reheat for when there is purchased heating at the HVAC system level but based on G3.1.1.3.1 it appears that all heating coils should be purchased heating when there is purchased heating in the building providing space heating.  If others disagree I can of course modify this but just wanted to highlight the assumption used in the logic above.
 
 
 **[Back](../../_toc.md)**

--- a/rct229/ruleset_functions/baseline_systems/is_baseline_system_6.py
+++ b/rct229/ruleset_functions/baseline_systems/is_baseline_system_6.py
@@ -1,0 +1,120 @@
+from rct229.data.schema_enums import schema_enums
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_cool_sources_none_or_null import (
+    are_all_terminal_cool_sources_none_or_null,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_fan_configs_parallel import (
+    are_all_terminal_fan_configs_parallel,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_heat_sources_electric import (
+    are_all_terminal_heat_sources_electric,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_heat_sources_hot_water import (
+    are_all_terminal_heat_sources_hot_water,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_heating_loops_purchased_heating import (
+    are_all_terminal_heating_loops_purchased_heating,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_types_VAV import (
+    are_all_terminal_types_VAV,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.do_all_terminals_have_one_fan import (
+    do_all_terminals_have_one_fan,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.does_each_zone_have_only_one_terminal import (
+    does_each_zone_have_only_one_terminal,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_cooling_type_DX import (
+    is_hvac_sys_cooling_type_dx,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_fan_sys_VSD import (
+    is_hvac_sys_fan_sys_vsd,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_preheat_fluid_loop_purchased_heating import (
+    is_hvac_sys_preheat_fluid_loop_purchased_heating,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_preheating_type_elec_resistance import (
+    is_hvac_sys_preheating_type_elec_resistance,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_preheating_type_fluid_loop import (
+    is_hvac_sys_preheating_type_fluid_loop,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_system_util import (
+    HVAC_SYS,
+    find_exactly_one_hvac_system,
+)
+
+HEATING_SYSTEM = schema_enums["HeatingSystemOptions"]
+COOLING_SYSTEM = schema_enums["CoolingSystemOptions"]
+
+
+def is_baseline_system_6(rmi_b, hvac_b_id, terminal_unit_id_list, zone_id_list):
+    """
+    Get either Sys-6, Sys-6b, or Not_Sys_6 string output which indicates whether the HVAC system is ASHRAE 90.1 2019 Appendix G system 6 (Package VAV with PFP Boxes) or system 6b (system 6 with purchased heating).
+
+    Parameters
+    ----------
+    rmi_b json
+         To evaluate if the hvac system is modeled as either Sys-11.1, Sys-11.1a, Sys-11b, Sys-11c, or Not_Sys_11.1 in the B_RMI.
+     hvac_b_id list
+         The id of the hvac system to evaluate.
+     terminal_unit_id_list
+         List list of terminal unit IDs associated with the HVAC system to be evaluated. These are sent to this function from the master get_baseline_system_types function.
+     zone_id_list list
+         list of zone IDs associated with the HVAC system to be evaluated. These are sent to this function from the master get_baseline_system_types function.
+
+    Returns
+    -------
+    The function returns either Sys-6, Sys-6b, or Not_Sys_6 string output which indicates whether the HVAC system is ASHRAE 90.1 2019 Appendix G system 6 (Package VAV with PFP Boxes) or system 6b (system 6 with purchased heating).
+    """
+
+    is_baseline_system_6 = HVAC_SYS.UNMATCHED
+
+    # Get the hvac system
+    hvac_b = find_exactly_one_hvac_system(rmi_b, hvac_b_id)
+
+    # check if the hvac system has the required sub systems for system type 11.1
+    has_required_heating_sys = (
+        hvac_b.get("heating_system") is None
+        or hvac_b["heating_system"].get("heating_system_type") is None
+        or hvac_b["heating_system"]["heating_system_type"] == HEATING_SYSTEM.NONE
+    )
+
+    has_required_preheat_sys = hvac_b.get("preheat_system") is not None
+
+    has_required_cooling_sys = (
+        hvac_b.get("cooling_system") is not None
+        or hvac_b["cooling_system"].get("cooling_system_type") is not None
+        or hvac_b["cooling_system"]["cooling_system_type"] != COOLING_SYSTEM.NONE
+    )
+
+    are_sys_data_matched = (
+        # short-circuit the logic if no required data is found.
+        has_required_heating_sys
+        and has_required_preheat_sys
+        and has_required_cooling_sys
+        # sub functions handles missing required sys, and return False.
+        and is_hvac_sys_cooling_type_dx(rmi_b, hvac_b_id)
+        and is_hvac_sys_fan_sys_vsd(rmi_b, hvac_b_id)
+        and does_each_zone_have_only_one_terminal(rmi_b, zone_id_list)
+        and are_all_terminal_cool_sources_none_or_null(rmi_b, terminal_unit_id_list)
+        and do_all_terminals_have_one_fan(rmi_b, terminal_unit_id_list)
+        and are_all_terminal_types_VAV(rmi_b, terminal_unit_id_list)
+        and are_all_terminal_fan_configs_parallel(rmi_b, terminal_unit_id_list)
+    )
+
+    if are_sys_data_matched:
+        if is_hvac_sys_preheating_type_elec_resistance(
+            rmi_b, hvac_b_id
+        ) and are_all_terminal_heat_sources_electric(rmi_b, terminal_unit_id_list):
+            is_baseline_system_6 = HVAC_SYS.SYS_6
+        elif (
+            is_hvac_sys_preheating_type_fluid_loop(rmi_b, hvac_b_id)
+            and is_hvac_sys_preheat_fluid_loop_purchased_heating(rmi_b, hvac_b_id)
+            and are_all_terminal_heat_sources_hot_water(rmi_b, terminal_unit_id_list)
+            and are_all_terminal_heating_loops_purchased_heating(
+                rmi_b, terminal_unit_id_list
+            )
+        ):
+            is_baseline_system_6 = HVAC_SYS.SYS_6B
+
+    return is_baseline_system_6

--- a/rct229/ruleset_functions/baseline_systems/is_baseline_system_8.py
+++ b/rct229/ruleset_functions/baseline_systems/is_baseline_system_8.py
@@ -1,0 +1,354 @@
+from rct229.data.schema_enums import schema_enums
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_cool_sources_none_or_null import (
+    are_all_terminal_cool_sources_none_or_null,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_fan_configs_parallel import (
+    are_all_terminal_fan_configs_parallel,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_heat_sources_electric import (
+    are_all_terminal_heat_sources_electric,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_heat_sources_hot_water import (
+    are_all_terminal_heat_sources_hot_water,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_heating_loops_purchased_heating import (
+    are_all_terminal_heating_loops_purchased_heating,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_terminal_types_VAV import (
+    are_all_terminal_types_VAV,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.do_all_terminals_have_one_fan import (
+    do_all_terminals_have_one_fan,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.does_each_zone_have_only_one_terminal import (
+    does_each_zone_have_only_one_terminal,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_cooling_type_fluid_loop import (
+    is_hvac_sys_cooling_type_fluid_loop,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_fan_sys_VSD import (
+    is_hvac_sys_fan_sys_vsd,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_fluid_loop_attached_to_chiller import (
+    is_hvac_sys_fluid_loop_attached_to_chiller,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_fluid_loop_purchased_CHW import (
+    is_hvac_sys_fluid_loop_purchased_chw,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_preheat_fluid_loop_purchased_heating import (
+    is_hvac_sys_preheat_fluid_loop_purchased_heating,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_preheating_type_elec_resistance import (
+    is_hvac_sys_preheating_type_elec_resistance,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.is_hvac_sys_preheating_type_fluid_loop import (
+    is_hvac_sys_preheating_type_fluid_loop,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_system_util import (
+    HVAC_SYS,
+    find_exactly_one_hvac_system,
+)
+
+HEATING_SYSTEM = schema_enums["HeatingSystemOptions"]
+
+
+def is_baseline_system_8(rmi_b, hvac_b_id, terminal_unit_id_list, zone_id_list):
+    """
+    Get either Sys-8, Sys-8a, Sys-8b, Sys-8c, or Not_Sys_8 string output which indicates whether the HVAC system is ASHRAE 90.1 2019 Appendix G system 8 (VAV with Parallel Fan-Powered Boxes and Reheat), system 8a (system 8 with purchased CHW), system 8b (system 8 with purchased heating), or 8c (system 8 with purchased heating and purchased chilled water).
+
+    Parameters
+    ----------
+    rmi_b json
+         To evaluate if the hvac system is modeled as either Sys-11.1, Sys-11.1a, Sys-11b, Sys-11c, or Not_Sys_11.1 in the B_RMI.
+     hvac_b_id list
+         The id of the hvac system to evaluate.
+     terminal_unit_id_list
+         List list of terminal unit IDs associated with the HVAC system to be evaluated. These are sent to this function from the master get_baseline_system_types function.
+     zone_id_list list
+         list of zone IDs associated with the HVAC system to be evaluated. These are sent to this function from the master get_baseline_system_types function.
+
+    Returns
+    -------
+    The function returns either Sys-8, Sys-8a, Sys-8b, Sys-8c, or Not_Sys_8 string output which indicates whether the HVAC system is ASHRAE 90.1 2019 Appendix G system 8 (VAV with Parallel Fan-Powered Boxes and Reheat ), system 8a (system 8 with purchased CHW), system 8b (system 8 with purchased heating), or 8c (system 8 with purchased heating and purchased chilled water).
+    """
+
+    is_baseline_system_8 = HVAC_SYS.UNMATCHED
+
+    # Get the hvac system
+    hvac_b = find_exactly_one_hvac_system(rmi_b, hvac_b_id)
+
+    # check if the hvac system has the required sub systems for system type 11.1
+    has_required_heating_sys = (
+        hvac_b.get("heating_system") is None
+        or hvac_b["heating_system"].get("heating_system_type") is None
+        or hvac_b["heating_system"]["heating_system_type"] == HEATING_SYSTEM.NONE
+    )
+
+    has_required_preheat_sys = hvac_b.get("preheat_system") is not None
+
+    are_sys_data_matched = (
+        # short-circuit the logic if no required data is found.
+        has_required_heating_sys
+        and has_required_preheat_sys
+        # sub functions handles missing required sys, and return False.
+        and is_hvac_sys_cooling_type_fluid_loop(rmi_b, hvac_b_id)
+        and is_hvac_sys_fan_sys_vsd(rmi_b, hvac_b_id)
+        and does_each_zone_have_only_one_terminal(rmi_b, zone_id_list)
+        and are_all_terminal_cool_sources_none_or_null(rmi_b, terminal_unit_id_list)
+        and do_all_terminals_have_one_fan(rmi_b, terminal_unit_id_list)
+        and are_all_terminal_types_VAV(rmi_b, terminal_unit_id_list)
+        and are_all_terminal_fan_configs_parallel(rmi_b, terminal_unit_id_list)
+    )
+
+    if are_sys_data_matched:
+        if is_hvac_sys_preheating_type_elec_resistance(
+            rmi_b, hvac_b_id
+        ) and are_all_terminal_heat_sources_electric(rmi_b, terminal_unit_id_list):
+            if is_hvac_sys_fluid_loop_attached_to_chiller(rmi_b, hvac_b_id):
+                is_baseline_system_8 = HVAC_SYS.SYS_8
+            elif is_hvac_sys_fluid_loop_purchased_chw(rmi_b, hvac_b_id):
+                is_baseline_system_8 = HVAC_SYS.SYS_8A
+        elif is_hvac_sys_preheating_type_fluid_loop(rmi_b, hvac_b_id):
+            if (
+                is_hvac_sys_preheat_fluid_loop_purchased_heating(rmi_b, hvac_b_id)
+                and are_all_terminal_heat_sources_hot_water(
+                    rmi_b, terminal_unit_id_list
+                )
+                and are_all_terminal_heating_loops_purchased_heating(
+                    rmi_b, terminal_unit_id_list
+                )
+            ):
+                if is_hvac_sys_fluid_loop_attached_to_chiller(rmi_b, hvac_b_id):
+                    is_baseline_system_8 = HVAC_SYS.SYS_8B
+                elif is_hvac_sys_fluid_loop_purchased_chw(rmi_b, hvac_b_id):
+                    is_baseline_system_8 = HVAC_SYS.SYS_8C
+
+    return is_baseline_system_8
+
+
+SYS_8_TEST_RMD = {
+    "id": "ASHRAE229 1",
+    "ruleset_model_instances": [
+        {
+            "id": "RMD 1",
+            "buildings": [
+                {
+                    "id": "Building 1",
+                    "building_open_schedule": "Required Building Schedule 1",
+                    "building_segments": [
+                        {
+                            "id": "Building Segment 1",
+                            "zones": [
+                                {
+                                    "id": "Thermal Zone 8",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 8",
+                                            "is_supply_ducted": True,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "ELECTRIC",
+                                            "heating_from_loop": "Boiler Loop 1",
+                                            "fan": {"id": "fan 8"},
+                                            "fan_configuration": "PARALLEL",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "id": "Thermal Zone 8a",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 8a",
+                                            "is_supply_ducted": True,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8a",
+                                            "heating_source": "ELECTRIC",
+                                            "heating_from_loop": "Boiler Loop 1",
+                                            "fan": {"id": "fan 8a"},
+                                            "fan_configuration": "PARALLEL",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "id": "Thermal Zone 8b",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 8b",
+                                            "is_supply_ducted": True,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8b",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan": {"id": "fan 8b"},
+                                            "fan_configuration": "PARALLEL",
+                                        }
+                                    ],
+                                },
+                                {
+                                    "id": "Thermal Zone 8c",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 8c",
+                                            "is_supply_ducted": True,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8c",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan": {"id": "fan 8c"},
+                                            "fan_configuration": "PARALLEL",
+                                        }
+                                    ],
+                                },
+                            ],
+                            "heating_ventilating_air_conditioning_systems": [
+                                {
+                                    "id": "System 8",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 1",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Secondary CHW Loop 1",
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 1",
+                                        "heating_system_type": "ELECTRIC_RESISTANCE",
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 8",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [{"id": "Supply Fan 1"}],
+                                        "return_fans": [{"id": "Return Fan 1"}],
+                                    },
+                                },
+                                {
+                                    "id": "System 8a",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 8a",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Purchased Chilled Water Loop 1",
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 8a",
+                                        "heating_system_type": "ELECTRIC_RESISTANCE",
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 8a",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [{"id": "Supply Fan 8a"}],
+                                        "return_fans": [{"id": "Return Fan 8a"}],
+                                    },
+                                },
+                                {
+                                    "id": "System 8b",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 8b",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Secondary CHW Loop 1",
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 8b",
+                                        "heating_system_type": "FLUID_LOOP",
+                                        "hot_water_loop": "Purchased HW Loop 1",
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 8b",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [{"id": "Supply Fan 1"}],
+                                        "return_fans": [{"id": "Return Fan 1"}],
+                                    },
+                                },
+                                {
+                                    "id": "System 8c",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 8C",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Purchased Chilled Water Loop 1",
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 8C",
+                                        "heating_system_type": "FLUID_LOOP",
+                                        "hot_water_loop": "Purchased HW Loop 1",
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 8C",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [{"id": "Supply Fan 1"}],
+                                        "return_fans": [{"id": "Return Fan 1"}],
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "boilers": [
+                {
+                    "id": "Boiler 1",
+                    "loop": "Boiler Loop 1",
+                    "energy_source_type": "NATURAL_GAS",
+                }
+            ],
+            "external_fluid_source": [
+                {
+                    "id": "Purchased CW 1",
+                    "loop": "Purchased Chilled Water Loop 1",
+                    "type": "CHILLED_WATER",
+                },
+                {
+                    "id": "Purchased HW 1",
+                    "loop": "Purchased HW Loop 1",
+                    "type": "HOT_WATER",
+                },
+                {
+                    "id": "Purchased CW 2",
+                    "loop": "Chilled Water Loop 2",
+                    "type": "CHILLED_WATER",
+                },
+            ],
+            "chillers": [{"id": "Chiller 1", "cooling_loop": "Chiller Loop 1"}],
+            "pumps": [
+                {
+                    "id": "Boiler Pump 1",
+                    "loop_or_piping": "Boiler Loop 1",
+                    "speed_control": "FIXED_SPEED",
+                },
+                {
+                    "id": "Chiller Pump 1",
+                    "loop_or_piping": "Chiller Loop 1",
+                    "speed_control": "FIXED_SPEED",
+                },
+                {
+                    "id": "Secondary CHW Pump",
+                    "loop_or_piping": "Secondary CHW Loop 1",
+                    "speed_control": "VARIABLE_SPEED",
+                },
+            ],
+            "fluid_loops": [
+                {"id": "Boiler Loop 1", "type": "HEATING"},
+                {"id": "Purchased HW Loop 1", "type": "HEATING"},
+                {
+                    "id": "Chiller Loop 1",
+                    "type": "COOLING",
+                    "child_loops": [{"id": "Secondary CHW Loop 1", "type": "COOLING"}],
+                },
+                {"id": "Purchased Chilled Water Loop 1", "type": "COOLING"},
+            ],
+        }
+    ],
+}
+
+
+a = is_baseline_system_8(
+    SYS_8_TEST_RMD["ruleset_model_instances"][0],
+    "System 8c",
+    ["VAV Air Terminal 8c"],
+    ["Thermal Zone 8c"],
+)
+print(a)

--- a/rct229/ruleset_functions/baseline_systems/test_is_baseline_system_6.py
+++ b/rct229/ruleset_functions/baseline_systems/test_is_baseline_system_6.py
@@ -1,9 +1,14 @@
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_test_util import (
+    load_system_test_file,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_system_util import HVAC_SYS
+from rct229.ruleset_functions.baseline_systems.is_baseline_system_6 import (
+    is_baseline_system_6,
+)
 from rct229.schema.validate import schema_validate_rmr
 
-# hvac_id = "System 6" => Sys_6, [Thermal Zone 1], [VAV Air Terminal 1]
-# hvac_id = "System 6b" => Sys_6b, [Thermal Zone 2], [VAV Air Terminal 2]
 
-SYS_6_RMD = {
+SYS_6_TEST_RMD = {
     "id": "ASHRAE229 1",
     "ruleset_model_instances": [
         {
@@ -45,7 +50,7 @@ SYS_6_RMD = {
                                             "type": "VARIABLE_AIR_VOLUME",
                                             "served_by_heating_ventilating_air_conditioning_system": "System 6B",
                                             "heating_source": "HOT_WATER",
-                                            "heating_from_loop": "Purchased HW 1",
+                                            "heating_from_loop": "Purchased HW Loop 1",
                                             "fan": {
                                                 "id": "Terminal Fan 2",
                                             },
@@ -81,7 +86,7 @@ SYS_6_RMD = {
                                     "preheat_system": {
                                         "id": "Preheat Coil 2",
                                         "heating_system_type": "FLUID_LOOP",
-                                        "hot_water_loop": "Purchased HW 1",
+                                        "hot_water_loop": "Purchased HW Loop 1",
                                     },
                                     "fan_system": {
                                         "id": "VAV Fan System 2",
@@ -116,7 +121,53 @@ SYS_6_RMD = {
 
 
 def test__TEST_RMD_baseline_system_6__is_valid():
-    schema_validation_result = schema_validate_rmr(SYS_6_RMD)
+    schema_validation_result = schema_validate_rmr(SYS_6_TEST_RMD)
     assert schema_validation_result[
         "passed"
     ], f"Schema error: {schema_validation_result['error']}"
+
+
+def test_is_baseline_system_6_true():
+    assert (
+        is_baseline_system_6(
+            SYS_6_TEST_RMD["ruleset_model_instances"][0],
+            "System 6",
+            ["VAV Air Terminal 1"],
+            ["Thermal Zone 1"],
+        )
+        == HVAC_SYS.SYS_6
+    )
+
+
+def test_is_baseline_system_6_test_json_true():
+    assert is_baseline_system_6(
+        load_system_test_file("System_6_PVAV_Elec_Reheat.json")[
+            "ruleset_model_instances"
+        ][0],
+        "System 6",
+        ["VAV Air Terminal 1"],
+        ["Thermal Zone 1"],
+    )
+
+
+def test_is_baseline_system_6B_true():
+    assert (
+        is_baseline_system_6(
+            SYS_6_TEST_RMD["ruleset_model_instances"][0],
+            "System 6B",
+            ["VAV Air Terminal 2"],
+            ["Thermal Zone 2"],
+        )
+        == HVAC_SYS.SYS_6B
+    )
+
+
+def test_is_baseline_system_6_test_json_true():
+    assert is_baseline_system_6(
+        load_system_test_file("System_6b_PVAV_Elec_Reheat.json")[
+            "ruleset_model_instances"
+        ][0],
+        "System 6",
+        ["VAV Air Terminal 1"],
+        ["Thermal Zone 1"],
+    )

--- a/rct229/ruleset_functions/baseline_systems/test_is_baseline_system_8.py
+++ b/rct229/ruleset_functions/baseline_systems/test_is_baseline_system_8.py
@@ -1,11 +1,13 @@
-# hvac_id = "System 8" => Sys_8, [Thermal Zone 8], [Air Terminal 8]
-# hvac_id = "System 8a" => Sys_8a, [Thermal Zone 8a], [Air Terminal 8a]
-# hvac_id = "System 8b" => Sys_8b, [Thermal Zone 8b], [Air Terminal 8b]
-# hvac_id = "System 8c" => Sys_8c, [Thermal Zone 8c], [Air Terminal 8c]
-
+from rct229.ruleset_functions.baseline_systems.baseline_hvac_test_util import (
+    load_system_test_file,
+)
+from rct229.ruleset_functions.baseline_systems.baseline_system_util import HVAC_SYS
+from rct229.ruleset_functions.baseline_systems.is_baseline_system_8 import (
+    is_baseline_system_8,
+)
 from rct229.schema.validate import schema_validate_rmr
 
-SYS_8_RMD = {
+SYS_8_TEST_RMD = {
     "id": "ASHRAE229 1",
     "ruleset_model_instances": [
         {
@@ -19,7 +21,7 @@ SYS_8_RMD = {
                             "id": "Building Segment 1",
                             "zones": [
                                 {
-                                    "id": "Thermal Zone 1",
+                                    "id": "Thermal Zone 8",
                                     "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
                                     "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                     "terminals": [
@@ -30,6 +32,7 @@ SYS_8_RMD = {
                                             "served_by_heating_ventilating_air_conditioning_system": "System 8",
                                             "heating_source": "ELECTRIC",
                                             "heating_from_loop": "Boiler Loop 1",
+                                            "fan": {"id": "fan 8"},
                                             "fan_configuration": "PARALLEL",
                                         }
                                     ],
@@ -46,6 +49,7 @@ SYS_8_RMD = {
                                             "served_by_heating_ventilating_air_conditioning_system": "System 8a",
                                             "heating_source": "ELECTRIC",
                                             "heating_from_loop": "Boiler Loop 1",
+                                            "fan": {"id": "fan 8a"},
                                             "fan_configuration": "PARALLEL",
                                         }
                                     ],
@@ -62,6 +66,7 @@ SYS_8_RMD = {
                                             "served_by_heating_ventilating_air_conditioning_system": "System 8b",
                                             "heating_source": "HOT_WATER",
                                             "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan": {"id": "fan 8b"},
                                             "fan_configuration": "PARALLEL",
                                         }
                                     ],
@@ -78,6 +83,7 @@ SYS_8_RMD = {
                                             "served_by_heating_ventilating_air_conditioning_system": "System 8c",
                                             "heating_source": "HOT_WATER",
                                             "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan": {"id": "fan 8c"},
                                             "fan_configuration": "PARALLEL",
                                         }
                                     ],
@@ -107,12 +113,11 @@ SYS_8_RMD = {
                                     "cooling_system": {
                                         "id": "CHW Coil 8a",
                                         "cooling_system_type": "FLUID_LOOP",
-                                        "chilled_water_loop": "Chilled Water Loop 1",
+                                        "chilled_water_loop": "Purchased Chilled Water Loop 1",
                                     },
                                     "preheat_system": {
                                         "id": "Preheat Coil 8a",
-                                        "heating_system_type": "FLUID_LOOP",
-                                        "hot_water_loop": "Boiler Loop 1",
+                                        "heating_system_type": "ELECTRIC_RESISTANCE",
                                     },
                                     "fan_system": {
                                         "id": "VAV Fan System 8a",
@@ -141,11 +146,11 @@ SYS_8_RMD = {
                                     },
                                 },
                                 {
-                                    "id": "System 8C",
+                                    "id": "System 8c",
                                     "cooling_system": {
                                         "id": "CHW Coil 8C",
                                         "cooling_system_type": "FLUID_LOOP",
-                                        "chilled_water_loop": "Chilled Water Loop 1",
+                                        "chilled_water_loop": "Purchased Chilled Water Loop 1",
                                     },
                                     "preheat_system": {
                                         "id": "Preheat Coil 8C",
@@ -174,7 +179,7 @@ SYS_8_RMD = {
             "external_fluid_source": [
                 {
                     "id": "Purchased CW 1",
-                    "loop": "Chilled Water Loop 1",
+                    "loop": "Purchased Chilled Water Loop 1",
                     "type": "CHILLED_WATER",
                 },
                 {
@@ -214,7 +219,7 @@ SYS_8_RMD = {
                     "type": "COOLING",
                     "child_loops": [{"id": "Secondary CHW Loop 1", "type": "COOLING"}],
                 },
-                {"id": "Chilled Water Loop 1", "type": "COOLING"},
+                {"id": "Purchased Chilled Water Loop 1", "type": "COOLING"},
             ],
         }
     ],
@@ -222,7 +227,97 @@ SYS_8_RMD = {
 
 
 def test__TEST_RMD_baseline_system_8__is_valid():
-    schema_validation_result = schema_validate_rmr(SYS_8_RMD)
+    schema_validation_result = schema_validate_rmr(SYS_8_TEST_RMD)
     assert schema_validation_result[
         "passed"
     ], f"Schema error: {schema_validation_result['error']}"
+
+
+def test_is_baseline_system_8_true():
+    assert (
+        is_baseline_system_8(
+            SYS_8_TEST_RMD["ruleset_model_instances"][0],
+            "System 8",
+            ["VAV Air Terminal 8"],
+            ["Thermal Zone 8"],
+        )
+        == HVAC_SYS.SYS_8
+    )
+
+
+def test_is_baseline_system_8_test_json_true():
+    assert is_baseline_system_8(
+        load_system_test_file("System_8_PFP_Reheat.json")["ruleset_model_instances"][0],
+        "System 8",
+        ["VAV Air Terminal 1"],
+        ["Thermal Zone 1"],
+    )
+
+
+def test_is_baseline_system_8A_true():
+    assert (
+        is_baseline_system_8(
+            SYS_8_TEST_RMD["ruleset_model_instances"][0],
+            "System 8a",
+            ["VAV Air Terminal 8a"],
+            ["Thermal Zone 8a"],
+        )
+        == HVAC_SYS.SYS_8A
+    )
+
+
+def test_is_baseline_system_8A_test_json_true():
+    assert is_baseline_system_8(
+        load_system_test_file("System_8a_PFP_Reheat.json")["ruleset_model_instances"][
+            0
+        ],
+        "System 8",
+        ["VAV Air Terminal 1"],
+        ["Thermal Zone 1"],
+    )
+
+
+def test_is_baseline_system_8B_true():
+    assert (
+        is_baseline_system_8(
+            SYS_8_TEST_RMD["ruleset_model_instances"][0],
+            "System 8b",
+            ["VAV Air Terminal 8b"],
+            ["Thermal Zone 8b"],
+        )
+        == HVAC_SYS.SYS_8B
+    )
+
+
+def test_is_baseline_system_8B_test_json_true():
+    assert is_baseline_system_8(
+        load_system_test_file("System_8b_PFP_Reheat.json")["ruleset_model_instances"][
+            0
+        ],
+        "System 8",
+        ["VAV Air Terminal 1"],
+        ["Thermal Zone 1"],
+    )
+
+
+def test_is_baseline_system_8C_true():
+    assert (
+        is_baseline_system_8(
+            SYS_8_TEST_RMD["ruleset_model_instances"][0],
+            "System 8c",
+            ["VAV Air Terminal 8c"],
+            ["Thermal Zone 8c"],
+        )
+        == HVAC_SYS.SYS_8C
+    )
+
+
+def test_is_baseline_system_8C_test_json_true():
+    assert is_baseline_system_8(
+        load_system_test_file("System_8c_PFP_Reheat.json")["ruleset_model_instances"][
+            0
+        ],
+        "System 8",
+        ["VAV Air Terminal 1"],
+        ["Thermal Zone 1"],
+    )

--- a/rct229/ruletest_engine/ruletest_jsons/system_types/System_8_PFP_Reheat.json
+++ b/rct229/ruletest_engine/ruletest_jsons/system_types/System_8_PFP_Reheat.json
@@ -1,0 +1,127 @@
+{
+    "id": "ASHRAE229 1",
+    "ruleset_model_instances": [
+        {
+            "id": "RMD 1",
+            "buildings": [
+                {
+                    "id": "Building 1",
+                    "building_open_schedule": "Required Building Schedule 1",
+                    "building_segments": [
+                        {
+                            "id": "Building Segment 1",
+                            "zones": [
+                                {
+                                    "id": "Thermal Zone 1",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 1",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Boiler Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "Thermal Zone 2",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 2",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Boiler Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "heating_ventilating_air_conditioning_systems": [
+                                {
+                                    "id": "System 8",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 1",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Secondary CHW Loop 1"
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 1",
+                                        "heating_system_type": "ELECTRIC_RESISTANCE"
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 1",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [
+                                            {
+                                                "id": "Supply Fan 1"
+                                            }
+                                        ],
+                                        "return_fans": [
+                                            {
+                                                "id": "Return Fan 1"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "boilers": [
+                {
+                    "id": "Boiler 1",
+                    "loop": "Boiler Loop 1",
+                    "energy_source_type": "NATURAL_GAS"
+                }
+            ],
+            "chillers": [
+                {
+                    "id": "Chiller 1",
+                    "cooling_loop": "Chiller Loop 1"
+                }
+            ],
+            "pumps": [
+                {
+                    "id": "Boiler Pump 1",
+                    "loop_or_piping": "Boiler Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                },
+                {
+                    "id": "Chiller Pump 1",
+                    "loop_or_piping": "Chiller Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                },
+                {
+                    "id": "Secondary CHW Pump",
+                    "loop_or_piping": "Secondary CHW Loop 1",
+                    "speed_control": "VARIABLE_SPEED"
+                }
+            ],
+            "fluid_loops": [
+                {
+                    "id": "Boiler Loop 1",
+                    "type": "HEATING"
+                },
+                {
+                    "id": "Chiller Loop 1",
+                    "type": "COOLING",
+                    "child_loops": [
+                        {
+                            "id": "Secondary CHW Loop 1",
+                            "type": "COOLING"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/rct229/ruletest_engine/ruletest_jsons/system_types/System_8a_PFP_Reheat.json
+++ b/rct229/ruletest_engine/ruletest_jsons/system_types/System_8a_PFP_Reheat.json
@@ -1,0 +1,118 @@
+{
+    "id": "ASHRAE229 1",
+    "ruleset_model_instances": [
+        {
+            "id": "RMD 1",
+            "buildings": [
+                {
+                    "id": "Building 1",
+                    "building_open_schedule": "Required Building Schedule 1",
+                    "building_segments": [
+                        {
+                            "id": "Building Segment 1",
+                            "zones": [
+                                {
+                                    "id": "Thermal Zone 1",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 1",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Boiler Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "Thermal Zone 2",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 2",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Boiler Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "heating_ventilating_air_conditioning_systems": [
+                                {
+                                    "id": "System 8",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 1",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Chilled Water Loop 1"
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 1",
+                                        "heating_system_type": "FLUID_LOOP",
+                                        "hot_water_loop": "Boiler Loop 1"
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 1",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [
+                                            {
+                                                "id": "Supply Fan 1"
+                                            }
+                                        ],
+                                        "return_fans": [
+                                            {
+                                                "id": "Return Fan 1"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "boilers": [
+                {
+                    "id": "Boiler 1",
+                    "loop": "Boiler Loop 1",
+                    "energy_source_type": "NATURAL_GAS"
+                }
+            ],
+            "external_fluid_source": [
+                {
+                    "id": "Purchased CW 1",
+                    "loop": "Chilled Water Loop 1",
+                    "type": "CHILLED_WATER"
+                }
+            ],
+            "pumps": [
+                {
+                    "id": "Boiler Pump 1",
+                    "loop_or_piping": "Boiler Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                },
+                {
+                    "id": "CHW Pump 1",
+                    "loop_or_piping": "Chilled Water Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                }
+            ],
+            "fluid_loops": [
+                {
+                    "id": "Boiler Loop 1",
+                    "type": "HEATING"
+                },
+                {
+                    "id": "Chilled Water Loop 1",
+                    "type": "COOLING"
+                }
+            ]
+        }
+    ]
+}

--- a/rct229/ruletest_engine/ruletest_jsons/system_types/System_8b_PFP_Reheat.json
+++ b/rct229/ruletest_engine/ruletest_jsons/system_types/System_8b_PFP_Reheat.json
@@ -1,0 +1,128 @@
+{
+    "id": "ASHRAE229 1",
+    "ruleset_model_instances": [
+        {
+            "id": "RMD 1",
+            "buildings": [
+                {
+                    "id": "Building 1",
+                    "building_open_schedule": "Required Building Schedule 1",
+                    "building_segments": [
+                        {
+                            "id": "Building Segment 1",
+                            "zones": [
+                                {
+                                    "id": "Thermal Zone 1",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 1",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "Thermal Zone 2",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 2",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "heating_ventilating_air_conditioning_systems": [
+                                {
+                                    "id": "System 8",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 1",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Secondary CHW Loop 1"
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 1",
+                                        "heating_system_type": "FLUID_LOOP",
+                                        "hot_water_loop": "Purchased HW Loop 1"
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 1",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [
+                                            {
+                                                "id": "Supply Fan 1"
+                                            }
+                                        ],
+                                        "return_fans": [
+                                            {
+                                                "id": "Return Fan 1"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "chillers": [
+                {
+                    "id": "Chiller 1",
+                    "cooling_loop": "Chiller Loop 1"
+                }
+            ],
+            "external_fluid_source": [
+                {
+                    "id": "Purchased HW 1",
+                    "loop": "Purchased HW Loop 1",
+                    "type": "HOT_WATER"
+                }
+            ],
+            "pumps": [
+                {
+                    "id": "HW Pump 1",
+                    "loop_or_piping": "Purchased HW Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                },
+                {
+                    "id": "Chiller Pump 1",
+                    "loop_or_piping": "Chiller Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                },
+                {
+                    "id": "Secondary CHW Pump",
+                    "loop_or_piping": "Secondary CHW Loop 1",
+                    "speed_control": "VARIABLE_SPEED"
+                }
+            ],
+            "fluid_loops": [
+                {
+                    "id": "Purchased HW Loop 1",
+                    "type": "HEATING"
+                },
+                {
+                    "id": "Chiller Loop 1",
+                    "type": "COOLING",
+                    "child_loops": [
+                        {
+                            "id": "Secondary CHW Loop 1",
+                            "type": "COOLING"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/rct229/ruletest_engine/ruletest_jsons/system_types/System_8c_PFP_Reheat.json
+++ b/rct229/ruletest_engine/ruletest_jsons/system_types/System_8c_PFP_Reheat.json
@@ -1,0 +1,116 @@
+{
+    "id": "ASHRAE229 1",
+    "ruleset_model_instances": [
+        {
+            "id": "RMD 1",
+            "buildings": [
+                {
+                    "id": "Building 1",
+                    "building_open_schedule": "Required Building Schedule 1",
+                    "building_segments": [
+                        {
+                            "id": "Building Segment 1",
+                            "zones": [
+                                {
+                                    "id": "Thermal Zone 1",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 1",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "Thermal Zone 2",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 2",
+                                            "is_supply_ducted": true,
+                                            "type": "VARIABLE_AIR_VOLUME",
+                                            "served_by_heating_ventilating_air_conditioning_system": "System 8",
+                                            "heating_source": "HOT_WATER",
+                                            "heating_from_loop": "Purchased HW Loop 1",
+                                            "fan_configuration": "PARALLEL"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "heating_ventilating_air_conditioning_systems": [
+                                {
+                                    "id": "System 8",
+                                    "cooling_system": {
+                                        "id": "CHW Coil 1",
+                                        "cooling_system_type": "FLUID_LOOP",
+                                        "chilled_water_loop": "Chilled Water Loop 1"
+                                    },
+                                    "preheat_system": {
+                                        "id": "Preheat Coil 1",
+                                        "heating_system_type": "FLUID_LOOP",
+                                        "hot_water_loop": "Purchased HW Loop 1"
+                                    },
+                                    "fan_system": {
+                                        "id": "VAV Fan System 1",
+                                        "fan_control": "VARIABLE_SPEED_DRIVE",
+                                        "supply_fans": [
+                                            {
+                                                "id": "Supply Fan 1"
+                                            }
+                                        ],
+                                        "return_fans": [
+                                            {
+                                                "id": "Return Fan 1"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "external_fluid_source": [
+                {
+                    "id": "Purchased HW 1",
+                    "loop": "Purchased HW Loop 1",
+                    "type": "HOT_WATER"
+                },
+                {
+                    "id": "Purchased CW 1",
+                    "loop": "Chilled Water Loop 1",
+                    "type": "CHILLED_WATER"
+                }
+            ],
+            "pumps": [
+                {
+                    "id": "HW Pump 1",
+                    "loop_or_piping": "Purchased HW Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                },
+                {
+                    "id": "CHW Pump 1",
+                    "loop_or_piping": "Chilled Water Loop 1",
+                    "speed_control": "FIXED_SPEED"
+                }
+            ],
+            "fluid_loops": [
+                {
+                    "id": "Purchased HW Loop 1",
+                    "type": "HEATING"
+                },
+                {
+                    "id": "Chilled Water Loop 1",
+                    "type": "COOLING"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR includes both ```is_baseline_system``` 6 and 8 developments and their pytest files. Thank you!