### PR TITLE
Updates to .coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,9 @@
 [run]
 branch = True
-omit = **/test_*, **/*_test*.*, **/__init__.py
+omit = **/test_*, **/*_test*.*, **/__init__.py, **/rules/**
 
 [report]
+show_missing = True
 skip_empty = True
 skip_covered = True
 sort = Cover

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ASHRAE Standard 229P is a proposed standard entitled, "Protocols for Evaluating 
 ## Introduction
 The Ruleset Checking Tool (RCT) is a Python package providing a command line tool for evaluating whether baseline and proposed Building Energy Models (BEM) meet the requirements of ANSI/ASHRAE/IES Standard 90.1-2019 Appendix G.  The tool accepts Ruleset Model Report (RMR) files representing the User, Baseline, and Proposed models as inputs, and generates an output report describing the RMR evalaution.
 
-**This is an early alpha version and is highly unstable!** 
+**This is an early alpha version and is highly unstable!**
 
 **This package will change significantly during the next several versions.**
 
@@ -54,6 +54,7 @@ Install `pipenv` using `pip`
 Now tests can be run by first installing dependencies and then running pytest.
 1. `pipenv install --dev`
 2. `pipenv run pytest`
+    - To see a coverage report, use `pipenv run pytest --cov`
 
 You can also package with pipenv to test the CLI tool.
 1. `pipenv install '-e .'`


### PR DESCRIPTION
Added `show_missing = True` and `omit `**/rules/**` to pytest coverage config file.