### PR TITLE
RCT/CH/fix-list_filter

### DIFF
--- a/rct229/rule_engine/rule_list_base.py
+++ b/rct229/rule_engine/rule_list_base.py
@@ -130,10 +130,9 @@ class RuleDefinitionListBase(RuleDefinitionBase):
 
         Returns
         -------
-        list of UserBaselineProposedVals
-            A filtered list of context trios
+        bool True iff context_item should passed through the filter.
         """
-        return context_item
+        return True
 
     def rule_check(self, context, calc_vals=None, data={}):
         """Overrides the base implementation to apply a rule to each entry in


### PR DESCRIPTION
I realized that the base implementation for list_path should return True instead of context_item. This worked since context_item was always Truthy, but it was still wrong.  I also fixed the methods documentation to match. 