### PR TITLE
RCT/YJ/branch_coverage_compare_standard_val

### DIFF
--- a/rct229/ruleset_functions/compare_schedule_test.py
+++ b/rct229/ruleset_functions/compare_schedule_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from rct229.ruleset_functions.compare_schedules import compare_schedules
 from rct229.utils.assertions import RCTFailureException
 

--- a/rct229/ruleset_functions/compare_standard_val_test.py
+++ b/rct229/ruleset_functions/compare_standard_val_test.py
@@ -26,7 +26,7 @@ def test__compare_standard_val_non_stringent_code_compare():
     assert compare_standard_val(False, 0.9999 * _M2, 1.0 * _M2)
 
 
-def test__compare_standard_val_strict_compare_gt():
+def test__compare_standard_val_strict_compare__gt():
     assert compare_standard_val_strict(True, 1.2 * _M2, 1.0 * _M2, operator.gt)
 
 

--- a/rct229/ruleset_functions/compare_standard_val_test.py
+++ b/rct229/ruleset_functions/compare_standard_val_test.py
@@ -3,6 +3,7 @@ import operator
 import pytest
 
 from rct229.ruleset_functions.compare_standard_val import compare_standard_val
+from rct229.ruleset_functions.compare_standard_val import compare_standard_val_strict
 from rct229.schema.config import ureg
 
 _M2 = ureg("m2")
@@ -23,3 +24,11 @@ def test__compare_standard_val_stringent_compare_gt_equal():
 
 def test__compare_standard_val_non_stringent_code_compare():
     assert compare_standard_val(False, 0.9999 * _M2, 1.0 * _M2)
+
+
+def test__compare_standard_val_strict_compare_gt():
+    assert compare_standard_val_strict(True, 1.2 * _M2, 1.0 * _M2, operator.gt)
+
+
+def test__compare_standard_val_strict_code_compare():
+    assert compare_standard_val_strict(False, 0.9999 * _M2, 1.0 * _M2) == False


### PR DESCRIPTION
This PR makes the ```compare_standard_val``` function achieve 100% branch coverage.  Thanks!