### PR TITLE
RCT/YJ/branch_coverage_get_dict_of_zones_and_terminal_units_served_by_hvac_sys

### DIFF
--- a/rct229/ruleset_functions/get_dict_of_zones_and_terminal_units_served_by_hvac_sys_test.py
+++ b/rct229/ruleset_functions/get_dict_of_zones_and_terminal_units_served_by_hvac_sys_test.py
@@ -29,10 +29,10 @@ TEST_BUILDING = {
                                 },
                                 {
                                     "id": "terminal_4",
-                                    # intentionally omit `served_by_heating_ventilating_air_conditioning_system` key to test 'if hvac_sys_id:' condition in in get_dict_of_zones_and_terminal_units_served_by_hvac_sys.py
+                                    # intentionally omit `served_by_heating_ventilating_air_conditioning_system` key to test 'if hvac_sys_id:' condition in get_dict_of_zones_and_terminal_units_served_by_hvac_sys.py
                                 },
                                 {
-                                    # intentionally added to test 'if terminal_id not in terminal_unit_list:' condition in get_dict_of_zones_and_terminal_units_served_by_hvac_sys.py
+                                    # intentionally added the duplicate to test 'if terminal_id not in terminal_unit_list:' condition in get_dict_of_zones_and_terminal_units_served_by_hvac_sys.py
                                     "id": "terminal_1",
                                     "served_by_heating_ventilating_air_conditioning_system": "hvac_1",
                                 },

--- a/rct229/ruleset_functions/get_dict_of_zones_and_terminal_units_served_by_hvac_sys_test.py
+++ b/rct229/ruleset_functions/get_dict_of_zones_and_terminal_units_served_by_hvac_sys_test.py
@@ -27,6 +27,15 @@ TEST_BUILDING = {
                                     "id": "terminal_3",
                                     "served_by_heating_ventilating_air_conditioning_system": "hvac_3",
                                 },
+                                {
+                                    "id": "terminal_4",
+                                    # intentionally omit `served_by_heating_ventilating_air_conditioning_system` key to test 'if hvac_sys_id:' condition in in get_dict_of_zones_and_terminal_units_served_by_hvac_sys.py
+                                },
+                                {
+                                    # intentionally added to test 'if terminal_id not in terminal_unit_list:' condition in get_dict_of_zones_and_terminal_units_served_by_hvac_sys.py
+                                    "id": "terminal_1",
+                                    "served_by_heating_ventilating_air_conditioning_system": "hvac_1",
+                                },
                             ],
                         },
                         {
@@ -52,6 +61,7 @@ TEST_BUILDING = {
         }
     ],
 }
+
 
 TEST_RMD = {"id": "ASHRAE229", "ruleset_model_instances": [TEST_BUILDING]}
 


### PR DESCRIPTION
This PR makes the ```get_dict_of_zones_and_terminal_units_served_by_hvac_sys``` function achieve 100% branch coverage. 