### PR TITLE
RCT/YJ/branch_coverage_get_hw_loop_zone_list_w_area

### DIFF
--- a/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_system_type_compare_test.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_system_type_compare_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from rct229.rulesets.ashrae9012019.ruleset_functions.baseline_system_type_compare import (
     baseline_system_type_compare,
 )

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/get_hw_loop_zone_list_w_area_dict.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/get_hw_loop_zone_list_w_area_dict.py
@@ -67,21 +67,23 @@ def get_hw_loop_zone_list_w_area(rmi_b):
                     hhw_loop_id = find_exactly_one_hvac_system(rmi_b, hvac_id)[
                         "heating_system"
                     ]["hot_water_loop"]
-            if type(hhw_loop_id) is str:
-                if hhw_loop_id not in hw_loop_zone_list_w_area_dict.keys():
-                    hw_loop_zone_list_w_area_dict[hhw_loop_id] = {
-                        "zone_list": [],
-                        "total_area": ZERO.AREA,
-                    }
-                # prevent double counting
-                if (
+
+            if (
+                hhw_loop_id is not None
+                and hhw_loop_id not in hw_loop_zone_list_w_area_dict.keys()
+            ):
+                hw_loop_zone_list_w_area_dict[hhw_loop_id] = {
+                    "zone_list": [],
+                    "total_area": ZERO.AREA,
+                }
+            # prevent double counting
+            if (
+                hhw_loop_id is not None
+                and zone["id"]
+                not in hw_loop_zone_list_w_area_dict[hhw_loop_id]["zone_list"]
+            ):
+                hw_loop_zone_list_w_area_dict[hhw_loop_id]["zone_list"].append(
                     zone["id"]
-                    not in hw_loop_zone_list_w_area_dict[hhw_loop_id]["zone_list"]
-                ):
-                    hw_loop_zone_list_w_area_dict[hhw_loop_id]["zone_list"].append(
-                        zone["id"]
-                    )
-                    hw_loop_zone_list_w_area_dict[hhw_loop_id][
-                        "total_area"
-                    ] += zone_area
+                )
+                hw_loop_zone_list_w_area_dict[hhw_loop_id]["total_area"] += zone_area
     return hw_loop_zone_list_w_area_dict

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/get_hw_loop_zone_list_w_area_dict_test.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/get_hw_loop_zone_list_w_area_dict_test.py
@@ -71,6 +71,42 @@ GET_HW_LOOP_ZONE_LIST_W_AREA_RMD = {
                                         }
                                     ],
                                 },
+                                {
+                                    "id": "Thermal Zone 4",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 4",
+                                            "is_supply_ducted": True,
+                                            # intentionally omitted `served_by_heating_ventilating_air_conditioning_system` key to test the `elif terminal.get("served_by_heating_ventilating_air_conditioning_system"):` condition
+                                        }
+                                    ],
+                                    "spaces": [
+                                        {
+                                            "id": "Space 4",
+                                            "floor_area": 30,
+                                        }
+                                    ],
+                                },
+                                {
+                                    "id": "Thermal Zone 5",
+                                    "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                                    "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                                    "terminals": [
+                                        {
+                                            "id": "VAV Air Terminal 5",
+                                            "is_supply_ducted": True,
+                                            "served_by_heating_ventilating_air_conditioning_system": "Electric Resistance System",
+                                        }
+                                    ],
+                                    "spaces": [
+                                        {
+                                            "id": "Space 5",
+                                            "floor_area": 30,
+                                        }
+                                    ],
+                                },
                             ],
                             "heating_ventilating_air_conditioning_systems": [
                                 {
@@ -107,6 +143,13 @@ GET_HW_LOOP_ZONE_LIST_W_AREA_RMD = {
                                         "id": "CAV Fan System 1",
                                         "fan_control": "CONSTANT",
                                         "supply_fans": [{"id": "Supply Fan 1"}],
+                                    },
+                                },
+                                {
+                                    "id": "Electric Resistance System",
+                                    "heating_system": {
+                                        "id": "Resistance 1",
+                                        "heating_system_type": "ELECTRIC_RESISTANCE",
                                     },
                                 },
                             ],

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/get_surface_conditioning_category_dict.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/get_surface_conditioning_category_dict.py
@@ -1,5 +1,4 @@
 import pandas as pd
-
 from rct229.rulesets.ashrae9012019.data.schema_enums import schema_enums
 from rct229.rulesets.ashrae9012019.ruleset_functions.get_zone_conditioning_category_dict import (
     ZoneConditioningCategory as ZCC,


### PR DESCRIPTION
This PR addresses achieving 100% branch coverage for the ```get_hw_loop_zone_list_w_area``` function.

Note)
1) I deleted ```if type(hhw_loop_id) is str:``` condition since this is validated against the schema.
2) When ```hhw_loop_id``` is ```None```, I edited not to include ```None``` type in the ```hw_loop_zone_list_w_area_dict```. Please let me know if the ```None``` type should be included. 