### PR TITLE
Update the secondary rule workflow

### DIFF
--- a/rct229/rule_engine/rule_base.py
+++ b/rct229/rule_engine/rule_base.py
@@ -158,6 +158,19 @@ class RuleDefinitionBase:
                                 # The result is a list of outcomes
                                 outcome["result"] = result
                             # Assume result type is bool
+                            # using is False to include the None case.
+                            elif self.is_primary_rule is False or data.get("is_primary_rule") is False:
+                                # secondary rule applicability check true-> undetermined, false -> not_applicable
+                                if result:
+                                    outcome["result"] = RCTOutcomeLabel.UNDETERMINED
+                                    undetermined_msg = self.get_manual_check_required_msg(context, calc_vals, data)
+                                    if undetermined_msg:
+                                        outcome["message"] = undetermined_msg
+                                else:
+                                    outcome["result"] = RCTOutcomeLabel.NOT_APPLICABLE
+                                    undetermined_msg = self.get_not_applicable_msg(context, data)
+                                    if undetermined_msg:
+                                        outcome["message"] = undetermined_msg
                             elif result:
                                 outcome["result"] = RCTOutcomeLabel.PASS
                                 pass_msg = self.get_pass_msg(context, calc_vals, data)
@@ -170,7 +183,7 @@ class RuleDefinitionBase:
                                     outcome["message"] = fail_msg
                     else:
                         outcome["result"] = RCTOutcomeLabel.NOT_APPLICABLE
-                        not_applicable_msg = self.get_not_applicable_msg(context, data)
+                        not_applicable_msg = self.get_not_applicable_msg(context, data=data)
                         if not_applicable_msg:
                             outcome["message"] = not_applicable_msg
                 except MissingKeyException as ke:
@@ -486,7 +499,7 @@ class RuleDefinitionBase:
 
         return True
 
-    def get_not_applicable_msg(self, context, data=None):
+    def get_not_applicable_msg(self, context, calc_vals=None, data=None):
         """Gets the message to include in the outcome for the NOT_APPLICABLE case.
 
         This base implementation simply returns the value of

--- a/rct229/rule_engine/rule_base.py
+++ b/rct229/rule_engine/rule_base.py
@@ -159,16 +159,25 @@ class RuleDefinitionBase:
                                 outcome["result"] = result
                             # Assume result type is bool
                             # using is False to include the None case.
-                            elif self.is_primary_rule is False or data.get("is_primary_rule") is False:
+                            elif (
+                                self.is_primary_rule is False
+                                or data.get("is_primary_rule") is False
+                            ):
                                 # secondary rule applicability check true-> undetermined, false -> not_applicable
                                 if result:
                                     outcome["result"] = RCTOutcomeLabel.UNDETERMINED
-                                    undetermined_msg = self.get_manual_check_required_msg(context, calc_vals, data)
+                                    undetermined_msg = (
+                                        self.get_manual_check_required_msg(
+                                            context, calc_vals, data
+                                        )
+                                    )
                                     if undetermined_msg:
                                         outcome["message"] = undetermined_msg
                                 else:
                                     outcome["result"] = RCTOutcomeLabel.NOT_APPLICABLE
-                                    undetermined_msg = self.get_not_applicable_msg(context, data)
+                                    undetermined_msg = self.get_not_applicable_msg(
+                                        context, data
+                                    )
                                     if undetermined_msg:
                                         outcome["message"] = undetermined_msg
                             elif result:
@@ -183,7 +192,9 @@ class RuleDefinitionBase:
                                     outcome["message"] = fail_msg
                     else:
                         outcome["result"] = RCTOutcomeLabel.NOT_APPLICABLE
-                        not_applicable_msg = self.get_not_applicable_msg(context, data=data)
+                        not_applicable_msg = self.get_not_applicable_msg(
+                            context, data=data
+                        )
                         if not_applicable_msg:
                             outcome["message"] = not_applicable_msg
                 except MissingKeyException as ke:

--- a/rct229/rule_engine/rule_base_test.py
+++ b/rct229/rule_engine/rule_base_test.py
@@ -90,7 +90,7 @@ class _DerivedRule(RuleDefinitionBase):
         return data == "MANUAL_CHECK_REQUIRED"
 
     def rule_check(self, context, calc_vals=None, data=None):
-        return type(data) is bool and data
+        return data["outcome"] is True
 
 
 DERIVED_RULE = _DerivedRule()
@@ -128,18 +128,33 @@ def test__rule_definition_base__evaluate__with_true_manual_check_required():
 
 
 def test__rule_definition_base__evaluate__with_true_rule_check():
-    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data=True) == {
+    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": True, "is_primary_rule": True}) == {
         **DERIVED_RULE_outcome_base,
-        "result": "PASSED",
+        "result": "PASS",
     }
 
 
-def test__rule_definition_base__evaluate__with_true_rule_check():
-    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data=False) == {
+def test__rule_definition_base__evaluate__with_false_rule_check():
+    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": False, "is_primary_rule": True}) == {
         **DERIVED_RULE_outcome_base,
         "result": "FAILED",
     }
 
+
+def test__rule_definition_base__evaluate__with_true_secondary_rule_check():
+    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": True, "is_primary_rule": False})== {
+        **DERIVED_RULE_outcome_base,
+        "result": "UNDETERMINED",
+        "message": "Manual check required message",
+    }
+
+
+def test__rule_definition_base__evaluate__with_false_secondary_rule_check():
+    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": False, "is_primary_rule": False})== {
+        **DERIVED_RULE_outcome_base,
+        "result": "NOT_APPLICABLE",
+        "message": "Not applicable message",
+    }
 
 # Testing RuleDefinitionBase get_context method ------------------
 def test__rule_definition_base__get_context__with_missing_rmrs():

--- a/rct229/rule_engine/rule_base_test.py
+++ b/rct229/rule_engine/rule_base_test.py
@@ -128,21 +128,30 @@ def test__rule_definition_base__evaluate__with_true_manual_check_required():
 
 
 def test__rule_definition_base__evaluate__with_true_rule_check():
-    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": True, "is_primary_rule": True}) == {
+    assert DERIVED_RULE.evaluate(
+        RMRS_WITH_MATCHING_USER_AND_BASELINE,
+        data={"outcome": True, "is_primary_rule": True},
+    ) == {
         **DERIVED_RULE_outcome_base,
         "result": "PASS",
     }
 
 
 def test__rule_definition_base__evaluate__with_false_rule_check():
-    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": False, "is_primary_rule": True}) == {
+    assert DERIVED_RULE.evaluate(
+        RMRS_WITH_MATCHING_USER_AND_BASELINE,
+        data={"outcome": False, "is_primary_rule": True},
+    ) == {
         **DERIVED_RULE_outcome_base,
         "result": "FAILED",
     }
 
 
 def test__rule_definition_base__evaluate__with_true_secondary_rule_check():
-    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": True, "is_primary_rule": False})== {
+    assert DERIVED_RULE.evaluate(
+        RMRS_WITH_MATCHING_USER_AND_BASELINE,
+        data={"outcome": True, "is_primary_rule": False},
+    ) == {
         **DERIVED_RULE_outcome_base,
         "result": "UNDETERMINED",
         "message": "Manual check required message",
@@ -150,11 +159,15 @@ def test__rule_definition_base__evaluate__with_true_secondary_rule_check():
 
 
 def test__rule_definition_base__evaluate__with_false_secondary_rule_check():
-    assert DERIVED_RULE.evaluate(RMRS_WITH_MATCHING_USER_AND_BASELINE, data={"outcome": False, "is_primary_rule": False})== {
+    assert DERIVED_RULE.evaluate(
+        RMRS_WITH_MATCHING_USER_AND_BASELINE,
+        data={"outcome": False, "is_primary_rule": False},
+    ) == {
         **DERIVED_RULE_outcome_base,
         "result": "NOT_APPLICABLE",
         "message": "Not applicable message",
     }
+
 
 # Testing RuleDefinitionBase get_context method ------------------
 def test__rule_definition_base__get_context__with_missing_rmrs():

--- a/rct229/rule_engine/rule_list_base.py
+++ b/rct229/rule_engine/rule_list_base.py
@@ -157,6 +157,8 @@ class RuleDefinitionListBase(RuleDefinitionBase):
         """
         # Merge in new data to be passed to the subrule indicated by each_rule
         data = {**data, **self.create_data(context, data)}
+        if "is_primary_rule" not in data.keys():
+            data["is_primary_rule"] = self.is_primary_rule
 
         # Create the context list
         # Note: create_context_list has access to the new data included just above

--- a/rct229/ruletest_engine/run_ruletests.py
+++ b/rct229/ruletest_engine/run_ruletests.py
@@ -134,7 +134,11 @@ def run_test_helper(test_list, ruleset_doc):
     return all(test_results)
 
 
-outcome = run_ashrae9012019_tests(section="section6")
+def run_test_one_jsontest(test_json):
+    return run_section_tests(test_json, RuleSet.ASHRAE9012019_RULESET)
+
+
+# outcome = run_ashrae9012019_tests(section="section6")
 
 # run_transformer_tests()
 # run_lighting_tests()
@@ -143,3 +147,5 @@ outcome = run_ashrae9012019_tests(section="section6")
 # run_envelope_tests()
 # run_receptacle_tests()
 # run_airside_tests()
+
+# run_test_one_jsontest("ashrae9012019/section5/rule_5_3.json")


### PR DESCRIPTION
Secondary rule check

I think the best option could be following exactly what we have right now.
In this proposed workflow, we will still use `calc_val` to do calculations and `rule_check` for applicability checking.

Rule_check returns `False`, then the engine returns `NOT_APPLICABLE`. otherwise, the engine returns `UNDETERMINED`.
In this way, we can also report the calculated values.

By using this implementation, Section5Rule3 does not need to modify the implementation at all. It naturally fits the workflow and produces secondary rule results. 

Let me know if this is a good approach. 
