### PR TITLE
RS/YJ/are_all_hvac_sys_fan_objs_autosized

### DIFF
--- a/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/are_all_hvac_sys_fan_objs_autosized.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/are_all_hvac_sys_fan_objs_autosized.py
@@ -2,7 +2,6 @@ from rct229.rulesets.ashrae9012019.ruleset_functions.get_dict_of_zones_and_termi
     get_dict_of_zones_and_terminal_units_served_by_hvac_sys,
 )
 from rct229.utils.assertions import getattr_
-from rct229.utils.assertions import assert_
 from rct229.utils.jsonpath_utils import find_all, find_one_with_field_value
 
 

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/are_all_hvac_sys_fan_objs_autosized.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/are_all_hvac_sys_fan_objs_autosized.py
@@ -2,7 +2,7 @@ from rct229.rulesets.ashrae9012019.ruleset_functions.get_dict_of_zones_and_termi
     get_dict_of_zones_and_terminal_units_served_by_hvac_sys,
 )
 from rct229.utils.assertions import getattr_
-from rct229.utils.jsonpath_utils import find_all, find_one_with_field_value
+from rct229.utils.jsonpath_utils import find_all
 
 
 def are_all_hvac_sys_fan_objs_autosized(rmi):
@@ -42,19 +42,22 @@ def are_all_hvac_sys_fan_objs_autosized(rmi):
             for terminal_id in zones_and_terminal_units_served_by_hvac_sys_dict[
                 hvac["id"]
             ]["terminal_unit_list"]:
-                terminal = find_one_with_field_value(
-                    "$.buildings[*].building_segments[*].zones[*].terminals[*]",
-                    "id",
-                    terminal_id,
+                terminals = find_all(
+                    f'$.buildings[*].building_segments[*].zones[*].terminals[*][?(@.id="{terminal_id}")]',
                     rmi,
                 )
-                if (
-                    getattr_(
-                        terminal, "is_airflow_autosized", "fan", "is_airflow_autosized"
-                    )
-                    == False
-                ):
-                    are_all_hvac_sys_fan_objs_autosized = False
-                    return are_all_hvac_sys_fan_objs_autosized
+
+                for terminal in terminals:
+                    if (
+                        getattr_(
+                            terminal,
+                            "is_airflow_autosized",
+                            "fan",
+                            "is_airflow_autosized",
+                        )
+                        == False
+                    ):
+                        are_all_hvac_sys_fan_objs_autosized = False
+                        return are_all_hvac_sys_fan_objs_autosized
 
     return are_all_hvac_sys_fan_objs_autosized

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/are_all_hvac_sys_fan_objs_autosized.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/are_all_hvac_sys_fan_objs_autosized.py
@@ -1,0 +1,61 @@
+from rct229.rulesets.ashrae9012019.ruleset_functions.get_dict_of_zones_and_terminal_units_served_by_hvac_sys import (
+    get_dict_of_zones_and_terminal_units_served_by_hvac_sys,
+)
+from rct229.utils.assertions import getattr_
+from rct229.utils.assertions import assert_
+from rct229.utils.jsonpath_utils import find_all, find_one_with_field_value
+
+
+def are_all_hvac_sys_fan_objs_autosized(rmi):
+    """Returns true or false. The function returns true if all supply fan objects associated with an hvac system are autosized.
+
+    Parameters
+    ----------
+    rmi: json
+         The RMR in which the fan system object is defined.
+
+    Returns
+    -------
+    bool
+        True: all supply fan objects associated with a hvac system are autosized.
+        False: not all supply fan objects associated with a hvac system are autosized.
+
+    """
+    are_all_hvac_sys_fan_objs_autosized = True
+
+    zones_and_terminal_units_served_by_hvac_sys_dict = (
+        get_dict_of_zones_and_terminal_units_served_by_hvac_sys(rmi)
+    )
+
+    for hvac in find_all(
+        "$.buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*]",
+        rmi,
+    ):
+        if hvac.get("fan_system") is not None:
+            for sup_fan in getattr_(hvac["fan_system"], "supply fans", "supply_fans"):
+                if (
+                    getattr_(sup_fan, "is airflow autosized", "is_airflow_autosized")
+                    == False
+                ):
+                    are_all_hvac_sys_fan_objs_autosized = False
+                    return are_all_hvac_sys_fan_objs_autosized
+        else:
+            for terminal_id in zones_and_terminal_units_served_by_hvac_sys_dict[
+                hvac["id"]
+            ]["terminal_unit_list"]:
+                terminal = find_one_with_field_value(
+                    "$.buildings[*].building_segments[*].zones[*].terminals[*]",
+                    "id",
+                    terminal_id,
+                    rmi,
+                )
+                if (
+                    getattr_(
+                        terminal, "is_airflow_autosized", "fan", "is_airflow_autosized"
+                    )
+                    == False
+                ):
+                    are_all_hvac_sys_fan_objs_autosized = False
+                    return are_all_hvac_sys_fan_objs_autosized
+
+    return are_all_hvac_sys_fan_objs_autosized

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/test_are_all_hvac_sys_fan_objs_autosized.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/baseline_systems/baseline_hvac_sub_functions/test_are_all_hvac_sys_fan_objs_autosized.py
@@ -1,0 +1,217 @@
+from rct229.rulesets.ashrae9012019.ruleset_functions.baseline_systems.baseline_hvac_sub_functions.are_all_hvac_sys_fan_objs_autosized import (
+    are_all_hvac_sys_fan_objs_autosized,
+)
+from rct229.schema.validate import schema_validate_rmr
+
+TEST_RMD_TRUE = {
+    "id": "test_rmd",
+    "buildings": [
+        {
+            "id": "Building 1",
+            "building_open_schedule": "Required Building Schedule 1",
+            "building_segments": [
+                {
+                    "id": "Building Segment 1",
+                    "zones": [
+                        {
+                            "id": "Thermal Zone 1",
+                            "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                            "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                            "terminals": [
+                                {
+                                    "id": "Air Terminal",
+                                    "type": "CONSTANT_AIR_VOLUME",
+                                    "served_by_heating_ventilating_air_conditioning_system": "System 3",
+                                    "fan": {
+                                        "id": "Terminal fan 1",
+                                        "is_airflow_autosized": True,
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                    "heating_ventilating_air_conditioning_systems": [
+                        {
+                            "id": "System 3",
+                            "heating_system": {
+                                "id": "Furnace Coil 1",
+                                "heating_system_type": "FURNACE",
+                                "energy_source_type": "NATURAL_GAS",
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+TEST_RMD_FAN_SYSTEM = {
+    "id": "test_rmd",
+    "buildings": [
+        {
+            "id": "Building 1",
+            "building_open_schedule": "Required Building Schedule 1",
+            "building_segments": [
+                {
+                    "id": "Building Segment 1",
+                    "zones": [
+                        {
+                            "id": "Thermal Zone 1",
+                            "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                            "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                            "terminals": [
+                                {
+                                    "id": "Air Terminal",
+                                    "type": "CONSTANT_AIR_VOLUME",
+                                }
+                            ],
+                        }
+                    ],
+                    "heating_ventilating_air_conditioning_systems": [
+                        {
+                            "id": "System 1",
+                            "heating_system": {
+                                "id": "Furnace Coil 1",
+                                "heating_system_type": "FURNACE",
+                                "energy_source_type": "NATURAL_GAS",
+                            },
+                            "fan_system": {
+                                "id": "CAV Fan System 1",
+                                "fan_control": "CONSTANT",
+                                "supply_fans": [
+                                    {"id": "Supply Fan 1", "is_airflow_autosized": True}
+                                ],
+                            },
+                        },
+                        {
+                            "id": "System 2",
+                            "heating_system": {
+                                "id": "Furnace Coil 1",
+                                "heating_system_type": "FURNACE",
+                                "energy_source_type": "NATURAL_GAS",
+                            },
+                            "fan_system": {
+                                "id": "CAV Fan System 1",
+                                "fan_control": "CONSTANT",
+                                "supply_fans": [
+                                    {
+                                        "id": "Supply Fan 1",
+                                        "is_airflow_autosized": False,
+                                    }
+                                ],
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+TEST_RMD_TERMINAL = {
+    "id": "test_rmd",
+    "buildings": [
+        {
+            "id": "Building 1",
+            "building_open_schedule": "Required Building Schedule 1",
+            "building_segments": [
+                {
+                    "id": "Building Segment 1",
+                    "zones": [
+                        {
+                            "id": "Thermal Zone 1",
+                            "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
+                            "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
+                            "terminals": [
+                                {
+                                    "id": "Air Terminal 1",
+                                    "type": "CONSTANT_AIR_VOLUME",
+                                    "served_by_heating_ventilating_air_conditioning_system": "System 1",
+                                    "fan": {
+                                        "id": "Terminal fan 1",
+                                        "is_airflow_autosized": True,
+                                    },
+                                },
+                                {
+                                    "id": "Air Terminal 2",
+                                    "type": "CONSTANT_AIR_VOLUME",
+                                    "served_by_heating_ventilating_air_conditioning_system": "System 2",
+                                    "fan": {
+                                        "id": "Terminal fan 2",
+                                        "is_airflow_autosized": False,
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                    "heating_ventilating_air_conditioning_systems": [
+                        {
+                            "id": "System 1",
+                            "heating_system": {
+                                "id": "Furnace Coil 1",
+                                "heating_system_type": "FURNACE",
+                                "energy_source_type": "NATURAL_GAS",
+                            },
+                        },
+                        {
+                            "id": "System 2",
+                            "heating_system": {
+                                "id": "Furnace Coil 1",
+                                "heating_system_type": "FURNACE",
+                                "energy_source_type": "NATURAL_GAS",
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+TEST_RMD_TRUE = {"id": "229_01", "ruleset_model_instances": [TEST_RMD_TRUE]}
+
+TEST_RMD_FULL_FAN_SYSTEM = {
+    "id": "229_01",
+    "ruleset_model_instances": [TEST_RMD_FAN_SYSTEM],
+}
+
+TEST_RMD_FULL_TERMINAL = {
+    "id": "229_01",
+    "ruleset_model_instances": [TEST_RMD_TERMINAL],
+}
+
+
+def test__TEST_RMD_TRUE__is_valid():
+    schema_validation_result = schema_validate_rmr(TEST_RMD_TRUE)
+    assert schema_validation_result[
+        "passed"
+    ], f"Schema error: {schema_validation_result['error']}"
+
+
+def test__TEST_RMD_FAN_SYSTEM__is_valid():
+    schema_validation_result = schema_validate_rmr(TEST_RMD_FULL_FAN_SYSTEM)
+    assert schema_validation_result[
+        "passed"
+    ], f"Schema error: {schema_validation_result['error']}"
+
+
+def test__TEST_RMD_TERMINAL__is_valid():
+    schema_validation_result = schema_validate_rmr(TEST_RMD_FULL_TERMINAL)
+    assert schema_validation_result[
+        "passed"
+    ], f"Schema error: {schema_validation_result['error']}"
+
+
+def test__are_all_hvac_sys_fan_objs_autosized__true():
+    assert are_all_hvac_sys_fan_objs_autosized(TEST_RMD_TRUE) == True
+
+
+def test__are_all_hvac_sys_fan_objs_autosized_fan__system_false():
+    assert are_all_hvac_sys_fan_objs_autosized(TEST_RMD_FAN_SYSTEM) == False
+
+
+def test__are_all_hvac_sys_fan_objs_autosized__terminal_false():
+    assert are_all_hvac_sys_fan_objs_autosized(TEST_RMD_TERMINAL) == False

--- a/rct229/schema/ASHRAE229.schema.json
+++ b/rct229/schema/ASHRAE229.schema.json
@@ -2648,6 +2648,10 @@
                     "type": "number",
                     "units": "L/s"
                 },
+                "is_airflow_autosized": {
+                    "description": "True if the airflow is automatically sized by the simulation software",
+                    "type": "boolean"
+                },
                 "specification_method": {
                     "description": "Options for how the fan is specified",
                     "$ref": "ASHRAE229.schema.json#/definitions/FanSpecificationMethodOptions"


### PR DESCRIPTION
This PR includes the ```are_all_hvac_sys_fan_objs_autosized``` function development. This function's unit test also achieved 100% branch coverage.