### PR TITLE
Updated scheduling to allow for 24 hour schedule

### DIFF
--- a/rct229/rulesets/ashrae9012019/ruleset_functions/is_economizer_modeled_in_proposed.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/is_economizer_modeled_in_proposed.py
@@ -34,14 +34,11 @@ def is_economizer_modeled_in_proposed(rmi_b, rmi_p, hvac_id_b):
         hvac_list_p = get_list_hvac_systems_associated_with_zone(rmi_p, zone_id_b)
         for hvac_id_p in hvac_list_p:
             hvac_p = find_exactly_one_hvac_system(rmi_p, hvac_id_p)
-            air_economizer_type_p = find_one(
-                "$.fan_system.air_economizer.type", hvac_p
-            )
+            air_economizer_type_p = find_one("$.fan_system.air_economizer.type", hvac_p)
             if (
-                    air_economizer_type_p is not None
-                    and air_economizer_type_p != Air_Economizer.FIXED_FRACTION
+                air_economizer_type_p is not None
+                and air_economizer_type_p != Air_Economizer.FIXED_FRACTION
             ):
                 is_economizer_modeled = True
 
     return is_economizer_modeled
-

--- a/rct229/ruletest_engine/ruletest_jsons/scripts/json_generation_utilities.py
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/json_generation_utilities.py
@@ -338,6 +338,11 @@ def create_schedule_list(schedule_str):
         schedule_list = [float(schedule_parameter)] * 8760
         return schedule_list
 
+    elif schedule_name == "CONSTANT_DAY":
+        # Return the schedule parameter 24 times
+        schedule_list = [float(schedule_parameter)] * 24
+        return schedule_list
+
     # If utilizing a predefined schedule from the schedule library, load it here
     elif schedule_name == "LIBRARY":
         # Load schedule JSON


### PR DESCRIPTION
Updated scheduling to allow for 24 hour schedule by utilizing enumeration "CONSTANT_DAY" after SCHEDULE.

This value feature is valuable when setting a schedule's hourly values. For example, "SCHEDULE:CONSTANT_DAY-1.0" will set a 24 length array with a constant value of 1.0.