### PR TITLE
Rule 19-12 corrections

### DIFF
--- a/rct229/rulesets/ashrae9012019/section19/section19rule12.py
+++ b/rct229/rulesets/ashrae9012019/section19/section19rule12.py
@@ -83,9 +83,9 @@ class Section19Rule12(RuleDefinitionListIndexedBase):
             )
 
             if climate_zone_b in CLIMATE_ZONE_70F:
-                req_high_limit_temp = 70 * ureg("degR")
+                req_high_limit_temp = 70 * ureg("degF")
             elif climate_zone_b in CLIMATE_ZONE_75F:
-                req_high_limit_temp = 75 * ureg("degR")
+                req_high_limit_temp = 75 * ureg("degF")
 
             return {
                 "high_limit_temp_b": high_limit_temp_b,
@@ -99,6 +99,6 @@ class Section19Rule12(RuleDefinitionListIndexedBase):
             air_economizer_type_b = calc_vals["air_economizer_type_b"]
 
             return (
-                std_equal(req_high_limit_temp, high_limit_temp_b)
+                std_equal(req_high_limit_temp.to(ureg.degK), high_limit_temp_b.to(ureg.degK))
                 and air_economizer_type_b == AIR_ECONOMIZER.TEMPERATURE
             )

--- a/rct229/rulesets/ashrae9012019/section19/section19rule12.py
+++ b/rct229/rulesets/ashrae9012019/section19/section19rule12.py
@@ -99,6 +99,8 @@ class Section19Rule12(RuleDefinitionListIndexedBase):
             air_economizer_type_b = calc_vals["air_economizer_type_b"]
 
             return (
-                std_equal(req_high_limit_temp.to(ureg.degK), high_limit_temp_b.to(ureg.degK))
+                std_equal(
+                    req_high_limit_temp.to(ureg.degK), high_limit_temp_b.to(ureg.degK)
+                )
                 and air_economizer_type_b == AIR_ECONOMIZER.TEMPERATURE
             )

--- a/rct229/rulesets/ashrae9012019/section19/section19rule2.py
+++ b/rct229/rulesets/ashrae9012019/section19/section19rule2.py
@@ -28,10 +28,7 @@ from rct229.rulesets.ashrae9012019.ruleset_functions.baseline_systems.baseline_s
     find_exactly_one_hvac_system,
 )
 from rct229.utils.assertions import getattr_
-from rct229.utils.jsonpath_utils import (
-    find_all,
-    find_one_with_field_value,
-)
+from rct229.utils.jsonpath_utils import find_all, find_one_with_field_value
 
 HEATING_SOURCE = schema_enums["HeatingSourceOptions"]
 FLUID_LOOP = schema_enums["FluidLoopOptions"]


### PR DESCRIPTION
Required high limit temperatures were in the wrong units. Also updated std_equal call to reference units in absolute temperature scales (e.g., Kelvin in this case).