### PR TITLE
Bug fixes and update for system to zone assignment 

### DIFF
--- a/rct229/rulesets/ashrae9012019/ruleset_functions/g311_exceptions/g311_sub_functions/get_predominant_hvac_building_area_type_test.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/g311_exceptions/g311_sub_functions/get_predominant_hvac_building_area_type_test.py
@@ -3,12 +3,12 @@ from copy import deepcopy
 from rct229.rulesets.ashrae9012019.ruleset_functions.g311_exceptions.g311_sub_functions.get_predominant_hvac_building_area_type import (
     get_predominant_hvac_building_area_type,
 )
-from rct229.schema.config import ureg
-from rct229.schema.schema_utils import quantify_rmr
-from rct229.schema.validate import schema_validate_rmr
 from rct229.rulesets.ashrae9012019.ruleset_functions.get_zone_conditioning_category_dict import (
     CAPACITY_THRESHOLD as CAPACITY_THRESHOLD_QUANTITY,
 )
+from rct229.schema.config import ureg
+from rct229.schema.schema_utils import quantify_rmr
+from rct229.schema.validate import schema_validate_rmr
 
 POWER_DELTA = 1
 POWER_THRESHOLD_100 = (CAPACITY_THRESHOLD_QUANTITY * 100 * ureg("m2")).to("W").magnitude

--- a/rct229/ruletest_engine/ruletest_jsons/scripts/excel_to_test_json_utilities.py
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/excel_to_test_json_utilities.py
@@ -986,9 +986,9 @@ def add_plant_loop_equipment(template_rmd, system_rmd):
 
     # Iterate through each RMR triplet dictionary
     for rmr_instance_dict in rmr_triplet_dict_list:
-        template_ruleset_model_instance = rmr_instance_dict["ruleset_model_descriptions"][
-            0
-        ]
+        template_ruleset_model_instance = rmr_instance_dict[
+            "ruleset_model_descriptions"
+        ][0]
 
         # Iterate through piece of plant loop equipment and check if any exist. Add any that are missing.
         for equipment in equipment_str_list:

--- a/rct229/ruletest_engine/ruletest_jsons/scripts/excel_to_test_json_utilities.py
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/excel_to_test_json_utilities.py
@@ -606,21 +606,21 @@ def set_systems_to_zones(json_dict, system_to_zone_dict, rule_set):
 
 
 def get_rmr_triplet_from_ruletest_json_dict(ruletest_json_test_dict):
-    """Reads in a ruletest JSON dictionary and returns list of RMRs for any triplet flagged in the ruletest JSON 
+    """Reads in a ruletest JSON dictionary and returns list of RMRs for any triplet flagged in the ruletest JSON
 
-            Parameters
-            ----------
+    Parameters
+    ----------
 
-            ruletest_json_test_dict : dict
+    ruletest_json_test_dict : dict
 
-                Dictionary corresponding to the JSON structure dictated by a ruletest spreadsheet test instance. This
-                is currently the top level instance and has keys such as Section, Rule, Test, standard (a dictionary)
-                and rmr transformations (the most relevant element for this function)
+        Dictionary corresponding to the JSON structure dictated by a ruletest spreadsheet test instance. This
+        is currently the top level instance and has keys such as Section, Rule, Test, standard (a dictionary)
+        and rmr transformations (the most relevant element for this function)
 
-            Returns
-            -------
-            rmr_triplet_dict_list: list
-                Returns a list of dictionaries, each representing an instance of an RMD
+    Returns
+    -------
+    rmr_triplet_dict_list: list
+        Returns a list of dictionaries, each representing an instance of an RMD
 
     """
 

--- a/rct229/ruletest_engine/ruletest_jsons/scripts/excel_to_test_json_utilities.py
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/excel_to_test_json_utilities.py
@@ -980,13 +980,13 @@ def add_plant_loop_equipment(template_rmd, system_rmd):
         "heat_rejections",
     ]
 
-    sys_ruleset_model_instance = system_rmd["ruleset_model_instances"][0]
+    sys_ruleset_model_instance = system_rmd["ruleset_model_descriptions"][0]
 
     rmr_triplet_dict_list = get_rmr_triplet_dicts_from_ruletest_json_dict(template_rmd)
 
     # Iterate through each RMR triplet dictionary
     for rmr_instance_dict in rmr_triplet_dict_list:
-        template_ruleset_model_instance = rmr_instance_dict["ruleset_model_instances"][
+        template_ruleset_model_instance = rmr_instance_dict["ruleset_model_descriptions"][
             0
         ]
 
@@ -1045,7 +1045,7 @@ def determine_system_classification(system_rmd):
 
     """
 
-    zones = system_rmd["ruleset_model_instances"][0]["buildings"][0][
+    zones = system_rmd["ruleset_model_descriptions"][0]["buildings"][0][
         "building_segments"
     ][0]["zones"]
 

--- a/rct229/ruletest_engine/ruletest_jsons/scripts/json_generation_utilities.py
+++ b/rct229/ruletest_engine/ruletest_jsons/scripts/json_generation_utilities.py
@@ -95,6 +95,58 @@ def get_nested_dic_from_key_list(dic, keys):
         return nested_dict[key][list_index]
 
 
+# Determines if a dictionary has an element after at a particular key list address
+def element_exists_at_key_address_in_dictionary(dic, keys):
+
+    last_key, last_index = parse_key_string(keys[-1])
+    first_key, first_index = parse_key_string(keys[0])
+
+    # Determine if a nested dictionary exists, slowly building on a reference nested dictionary each iteration through the loop.
+    for key in keys:
+        # Parse key and determine if this key references a list or a value. If list_index returns an integer (i.e., a
+        # reference index in a list) this key represents a list in the dictionary and needs to be set differently
+        # EXAMPLE: The key "buildings[0]" implies the "buildings" key represents a list. We set the value at
+        # element 0 in the this list
+
+        key, list_index = parse_key_string(key)
+        is_list = isinstance(list_index, int)
+
+        # If this is the first key, set the reference dictionary to the highest level dictionary and work down from
+        # there.
+        if key == first_key:
+            # If first key isn't initialized, return False
+            if key not in dic:
+                return False
+
+            if is_list:
+                reference_dict = dic[key][first_index]
+            else:
+                reference_dict = dic[key]
+
+        # If the final key and something is found, return True
+        elif key == last_key:
+            if key not in reference_dict:
+                return False
+
+            return True
+
+        # If neither the first nor final key in list, continue drilling down through nested dictionaries.
+        else:
+            if key not in reference_dict:
+                return False
+
+            # If this element in the key_list references a list, index the value defined in 'list_index', else reference
+            # the single value specified by the key.
+            if is_list:
+                # If list isn't long enough, append a new dictionary to it to avoid index out of bounds
+                # print(reference_dict[key])
+                while len(reference_dict[key]) < list_index + 1:
+                    reference_dict[key].append({})
+                reference_dict = reference_dict[key][list_index]
+            else:
+                reference_dict = reference_dict[key]
+
+
 def parse_key_string(key_string):
     """Inspects a string representing a key for any list references. Returns the parsed 'key' and 'list_index' reference
     Example: 'surfaces[1]' references a key = 'surfaces' which represents a list. The '[1]' implies a reference


### PR DESCRIPTION
- Updated references to ruleset_model_instances to ruleset_model_descriptions to update to 0.29 schema.
- Fixed issue where HVAC assignments were only being applied to the first Test ID in a ruletest excel file
- Fixed issue where setting multizone air loop names broke code if no HVAC systems had been set in a building segment yet