### PR TITLE
RCT/YJ/Adding ```Evaluation Process``` print out feature

### DIFF
--- a/rct229/cli.py
+++ b/rct229/cli.py
@@ -42,7 +42,7 @@ def run_test(ruleset, section=None):
         print(f"software test workflow for section {section}")
     if ruleset == RuleSet.ASHRAE9012019_RULESET:
         SchemaStore.set_ruleset(RuleSet.ASHRAE9012019_RULESET)
-        outcome_list = run_ashrae9012019_tests(section, True)
+        outcome_list = run_ashrae9012019_tests(section, eval_proc_print=True)
         if section is None:
             for idx, outcome in enumerate(outcome_list):
                 assert (

--- a/rct229/cli.py
+++ b/rct229/cli.py
@@ -7,10 +7,7 @@ from rct229.ruletest_engine.run_ruletests import run_ashrae9012019_tests
 from rct229.schema.schema_enums import SchemaEnums
 from rct229.schema.schema_store import SchemaStore
 from rct229.utils.assertions import RCTException
-from rct229.ruleset_functions import (
-    count_number_of_rules,
-    count_number_of_ruletest_cases,
-)
+from rct229.web_application import count_number_of_rules, count_number_of_ruletest_cases
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 

--- a/rct229/cli.py
+++ b/rct229/cli.py
@@ -7,7 +7,10 @@ from rct229.ruletest_engine.run_ruletests import run_ashrae9012019_tests
 from rct229.schema.schema_enums import SchemaEnums
 from rct229.schema.schema_store import SchemaStore
 from rct229.utils.assertions import RCTException
-from rct229.web_application import count_number_of_rules, count_number_of_ruletest_cases
+from rct229.ruleset_functions import (
+    count_number_of_rules,
+    count_number_of_ruletest_cases,
+)
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -38,10 +41,11 @@ test_short_help_text = """
 @click.option("--ruleset", "-rs", multiple=False, default="ashrae9012019")
 @click.argument("section", type=click.STRING, required=False)
 def run_test(ruleset, section=None):
-    print(f"software test workflow for section {section}")
+    if section is not None:
+        print(f"software test workflow for section {section}")
     if ruleset == RuleSet.ASHRAE9012019_RULESET:
         SchemaStore.set_ruleset(RuleSet.ASHRAE9012019_RULESET)
-        outcome_list = run_ashrae9012019_tests(section)
+        outcome_list = run_ashrae9012019_tests(section, True)
         if section is None:
             for idx, outcome in enumerate(outcome_list):
                 assert (

--- a/rct229/rule_engine/engine.py
+++ b/rct229/rule_engine/engine.py
@@ -102,7 +102,7 @@ def evaluate_all_rules(ruleset_model_path_list):
     return report
 
 
-def evaluate_rule(rule, rmrs, test=False, ten_percent_print=False):
+def evaluate_rule(rule, rmrs, test=False, eval_proc_print=False):
     """Evaluates a single rule against an RMD trio
 
     Parameters
@@ -111,7 +111,7 @@ def evaluate_rule(rule, rmrs, test=False, ten_percent_print=False):
         Object containing the RMDs required by enum schema
     test: Boolean
         A flag to indicate whether the evaluate rule is a software test workflow or not.
-    ten_percent_print: Boolean
+    eval_proc_print: Boolean
         whether to print out the evaluation process print: True: print out, False: NOT print out
 
     Returns
@@ -133,7 +133,7 @@ def evaluate_rule(rule, rmrs, test=False, ten_percent_print=False):
         }
     """
 
-    return evaluate_rules([rule], rmrs, test=test, ten_percent_print=ten_percent_print)
+    return evaluate_rules([rule], rmrs, test=test, eval_proc_print=eval_proc_print)
 
 
 def evaluate_rules(
@@ -141,7 +141,7 @@ def evaluate_rules(
     rmds: RuleSetModels,
     unit_system=UNIT_SYSTEM.IP,
     test=False,
-    ten_percent_print=False,
+    eval_proc_print=False,
 ):
     """Evaluates a list of rules against an RMDs
 
@@ -153,7 +153,7 @@ def evaluate_rules(
         Object containing RPDs for ruleset evaluation
     test: Boolean
         Flag to indicate whether this run is for software testing workflow or not
-    ten_percent_print: Boolean
+    eval_proc_print: Boolean
         whether to print out the evaluation process print: True: print out, False: NOT print out
 
     Returns
@@ -237,7 +237,7 @@ def evaluate_rules(
             print(
                 f"Compliance evaluation progress: {round(rule_counter / total_num_rules * 100)}%"
             )
-        if not ten_percent_print:
+        if not eval_proc_print:
             print(f"Processing Rule {rule.id}")
         outcome = rule.evaluate(copied_rmds)
         outcomes.append(outcome)

--- a/rct229/rule_engine/engine.py
+++ b/rct229/rule_engine/engine.py
@@ -142,7 +142,7 @@ def evaluate_rules(
     unit_system=UNIT_SYSTEM.IP,
     test=False,
     session_id="",
-    eval_proc_print=False
+    eval_proc_print=False,
 ):
     """Evaluates a list of rules against an RMDs
 

--- a/rct229/rule_engine/engine.py
+++ b/rct229/rule_engine/engine.py
@@ -102,7 +102,7 @@ def evaluate_all_rules(ruleset_model_path_list):
     return report
 
 
-def evaluate_rule(rule, rmrs, test=False):
+def evaluate_rule(rule, rmrs, test=False, ten_percent_print=False):
     """Evaluates a single rule against an RMD trio
 
     Parameters
@@ -111,6 +111,8 @@ def evaluate_rule(rule, rmrs, test=False):
         Object containing the RMDs required by enum schema
     test: Boolean
         A flag to indicate whether the evaluate rule is a software test workflow or not.
+    ten_percent_print: Boolean
+        whether to print out the evaluation process print: True: print out, False: NOT print out
 
     Returns
     -------
@@ -131,11 +133,15 @@ def evaluate_rule(rule, rmrs, test=False):
         }
     """
 
-    return evaluate_rules([rule], rmrs, test=test)
+    return evaluate_rules([rule], rmrs, test=test, ten_percent_print=ten_percent_print)
 
 
 def evaluate_rules(
-    rules_list: list, rmds: RuleSetModels, unit_system=UNIT_SYSTEM.IP, test=False
+    rules_list: list,
+    rmds: RuleSetModels,
+    unit_system=UNIT_SYSTEM.IP,
+    test=False,
+    ten_percent_print=False,
 ):
     """Evaluates a list of rules against an RMDs
 
@@ -146,7 +152,9 @@ def evaluate_rules(
     rmds : RuleSetModels
         Object containing RPDs for ruleset evaluation
     test: Boolean
-        Flag to indicate whether this run is for software testing workflow or not.
+        Flag to indicate whether this run is for software testing workflow or not
+    ten_percent_print: Boolean
+        whether to print out the evaluation process print: True: print out, False: NOT print out
 
     Returns
     -------
@@ -229,7 +237,8 @@ def evaluate_rules(
             print(
                 f"Compliance evaluation progress: {round(rule_counter / total_num_rules * 100)}%"
             )
-        print(f"Processing Rule {rule.id}")
+        if not ten_percent_print:
+            print(f"Processing Rule {rule.id}")
         outcome = rule.evaluate(copied_rmds)
         outcomes.append(outcome)
 

--- a/rct229/ruletest_engine/ruletest_engine.py
+++ b/rct229/ruletest_engine/ruletest_engine.py
@@ -403,14 +403,18 @@ def generate_rct_outcomes_list_from_section_list(section_list):
 
     # Maps section lists to their titles
     section_dict = {
+        "1": "Performance Calculations",
+        "4": "Schedules Setpoints",
         "5": "Envelope",
         "6": "Lighting",
+        "10": "HVAC General",
         "12": "Receptacles",
         "15": "Transformers",
-        "19": "HVAC-Airside",
-        "21": "HVAC-WaterSide",
-        "22": "HVAC-Chiller",
-        "23": "HVAC-SystemSpecificRequirements",
+        "18": "HVAC-Baseline",
+        "19": "HVAC-General",
+        "21": "HVAC-HotWaterSide",
+        "22": "HVAC-ChilledWaterSide",
+        "23": "HVAC-AirSide"
     }
 
     # Maps excel enumerations for pass/fail etc. to RCTOutcomeLabel. Unfortunately there's a disconnect.

--- a/rct229/ruletest_engine/ruletest_engine.py
+++ b/rct229/ruletest_engine/ruletest_engine.py
@@ -174,7 +174,9 @@ def process_test_result(test_result, test_dict, test_id):
     return outcome_text, received_expected_outcome
 
 
-def run_section_tests(test_json_name: str, ruleset_doc: RuleSet):
+def run_section_tests(
+    test_json_name: str, ruleset_doc: RuleSet, ten_percent_print=False
+):
     """Runs all tests found in a given test JSON and prints results to console. Returns true/false describing whether
     or not all tests in the JSON result in the expected outcome.
 
@@ -187,6 +189,10 @@ def run_section_tests(test_json_name: str, ruleset_doc: RuleSet):
     ruleset_doc: string
 
         Name of the ruleset
+
+    ten_percent_print: bool
+
+        whether to print out the evaluation process print: True: print out, False: NOT print out
 
     Returns
     -------
@@ -265,7 +271,9 @@ def run_section_tests(test_json_name: str, ruleset_doc: RuleSet):
             continue
 
         # Evaluate rule and check for invalid RMRs
-        evaluation_dict = evaluate_rule(rule, rmr_trio, True)
+        evaluation_dict = evaluate_rule(
+            rule, rmr_trio, True, ten_percent_print=ten_percent_print
+        )
         # pprint.pprint(evaluation_dict)
         invalid_rmrs_dict = evaluation_dict["invalid_rmrs"]
 
@@ -317,10 +325,8 @@ def run_section_tests(test_json_name: str, ruleset_doc: RuleSet):
                     print(test_result_string)
 
     # Print results to console
-    if all_tests_pass:
-        print("All tests passed!")
-
-    print("")  # Buffer line
+    if all_tests_pass and not ten_percent_print:
+        print("All tests passed!\n")
 
     # Return whether or not all tests in this test JSON received their expected outcome as a boolean
     all_tests_successful = all(test_result_dict["results"])

--- a/rct229/ruletest_engine/ruletest_engine.py
+++ b/rct229/ruletest_engine/ruletest_engine.py
@@ -174,9 +174,7 @@ def process_test_result(test_result, test_dict, test_id):
     return outcome_text, received_expected_outcome
 
 
-def run_section_tests(
-    test_json_name: str, ruleset_doc: RuleSet, eval_proc_print=False
-):
+def run_section_tests(test_json_name: str, ruleset_doc: RuleSet, eval_proc_print=False):
     """Runs all tests found in a given test JSON and prints results to console. Returns true/false describing whether
     or not all tests in the JSON result in the expected outcome.
 

--- a/rct229/ruletest_engine/ruletest_engine.py
+++ b/rct229/ruletest_engine/ruletest_engine.py
@@ -175,7 +175,7 @@ def process_test_result(test_result, test_dict, test_id):
 
 
 def run_section_tests(
-    test_json_name: str, ruleset_doc: RuleSet, ten_percent_print=False
+    test_json_name: str, ruleset_doc: RuleSet, eval_proc_print=False
 ):
     """Runs all tests found in a given test JSON and prints results to console. Returns true/false describing whether
     or not all tests in the JSON result in the expected outcome.
@@ -190,7 +190,7 @@ def run_section_tests(
 
         Name of the ruleset
 
-    ten_percent_print: bool
+    eval_proc_print: bool
 
         whether to print out the evaluation process print: True: print out, False: NOT print out
 
@@ -272,7 +272,7 @@ def run_section_tests(
 
         # Evaluate rule and check for invalid RMRs
         evaluation_dict = evaluate_rule(
-            rule, rmr_trio, True, ten_percent_print=ten_percent_print
+            rule, rmr_trio, True, eval_proc_print=eval_proc_print
         )
         # pprint.pprint(evaluation_dict)
         invalid_rmrs_dict = evaluation_dict["invalid_rmrs"]
@@ -325,7 +325,7 @@ def run_section_tests(
                     print(test_result_string)
 
     # Print results to console
-    if all_tests_pass and not ten_percent_print:
+    if all_tests_pass and not eval_proc_print:
         print("All tests passed!\n")
 
     # Return whether or not all tests in this test JSON received their expected outcome as a boolean

--- a/rct229/ruletest_engine/run_ruletests.py
+++ b/rct229/ruletest_engine/run_ruletests.py
@@ -8,7 +8,7 @@ TEST_PATH = "ruletest_jsons"
 
 
 def run_ashrae9012019_tests(
-    section: str = None, ten_percent_print: bool = False
+    section: str = None, eval_proc_print: bool = False
 ) -> list[bool]:
     """
     Run ruleset by section or all
@@ -17,7 +17,7 @@ def run_ashrae9012019_tests(
     Parameters
     ----------
     section: str - it should be the same string in the ASHRAE9012019_TEST_PATH_LIST
-    ten_percent_print: bool - if True, evaluation process will be printed with 10% increments and "Processing Rule" won't be printed.
+    eval_proc_print: bool - if True, evaluation process will be printed with 10% increments and "Processing Rule" won't be printed.
                           if False, evaluation process will NOT be printed and "Processing Rule" will be printed.
 
     Returns
@@ -25,7 +25,7 @@ def run_ashrae9012019_tests(
 
     """
 
-    if ten_percent_print:
+    if eval_proc_print:
         # get all the list of rpd file names
         rpd_by_section_list = [
             _helper_get_all_test_file_by_section(
@@ -53,7 +53,7 @@ def run_ashrae9012019_tests(
 
             # test each ruleset and save the bool result
             outcome_by_section[section].append(
-                run_test_helper([rpd], RuleSet.ASHRAE9012019_RULESET, ten_percent_print)
+                run_test_helper([rpd], RuleSet.ASHRAE9012019_RULESET, eval_proc_print)
             )
 
             # check if the progress has reached or exceeded the next progress update
@@ -226,12 +226,12 @@ def run_sys_zone_assignment_tests():
     return run_test_helper(json_tests, RuleSet.ASHRAE9012019_RULESET)
 
 
-def run_test_helper(test_list, ruleset_doc, ten_percent_print=False):
+def run_test_helper(test_list, ruleset_doc, eval_proc_print=False):
     # sort the list in a human order
     test_list.sort(key=natural_keys)
     # all will short-circuit the tests - to avoid it, split the code into two lines.
     test_results = [
-        run_section_tests(test_json, ruleset_doc, ten_percent_print)
+        run_section_tests(test_json, ruleset_doc, eval_proc_print)
         for test_json in test_list
     ]
     return all(test_results)
@@ -258,7 +258,7 @@ def run_test_one_jsontest(test_json):
 # run_hvac_general_tests()
 
 # run_test_one_jsontest("ashrae9012019/section4/rule_4_2.json")
-# run_ashrae9012019_tests(ten_percent_print=False)
+run_ashrae9012019_tests(eval_proc_print=True)
 # output_dir = os.path.dirname(__file__)
 # generate_ashrae9012019_software_test_report(['tester'])
 # generate_ashrae9012019_software_test_report(None, output_dir)

--- a/rct229/ruletest_engine/run_ruletests.py
+++ b/rct229/ruletest_engine/run_ruletests.py
@@ -258,7 +258,7 @@ def run_test_one_jsontest(test_json):
 # run_hvac_general_tests()
 
 # run_test_one_jsontest("ashrae9012019/section4/rule_4_2.json")
-run_ashrae9012019_tests(eval_proc_print=True)
+run_ashrae9012019_tests(eval_proc_print=False)
 # output_dir = os.path.dirname(__file__)
 # generate_ashrae9012019_software_test_report(['tester'])
 # generate_ashrae9012019_software_test_report(None, output_dir)

--- a/rct229/ruletest_engine/run_ruletests.py
+++ b/rct229/ruletest_engine/run_ruletests.py
@@ -18,7 +18,7 @@ def run_ashrae9012019_tests(
     ----------
     section: str - it should be the same string in the ASHRAE9012019_TEST_PATH_LIST
     eval_proc_print: bool - if True, evaluation process will be printed with 10% increments and "Processing Rule" won't be printed.
-                          if False, evaluation process will NOT be printed and "Processing Rule" will be printed.
+                            if False, evaluation process will NOT be printed and "Processing Rule" will be printed.
 
     Returns
     -------
@@ -258,7 +258,7 @@ def run_test_one_jsontest(test_json):
 # run_hvac_general_tests()
 
 # run_test_one_jsontest("ashrae9012019/section4/rule_4_2.json")
-run_ashrae9012019_tests(eval_proc_print=False)
+# run_ashrae9012019_tests(eval_proc_print=False)
 # output_dir = os.path.dirname(__file__)
 # generate_ashrae9012019_software_test_report(['tester'])
 # generate_ashrae9012019_software_test_report(None, output_dir)

--- a/rct229/web_application.py
+++ b/rct229/web_application.py
@@ -3,8 +3,8 @@ import os
 import rct229.rulesets as rulesets
 import rct229.rulesets as rs
 from rct229.reports import reports as rct_report
-from rct229.rule_engine.engine import evaluate_all_rules, evaluate_all_rules_rpd
-from rct229.rule_engine.rulesets import RuleSet, RuleSetTest
+from rct229.rule_engine.engine import evaluate_all_rules_rpd
+from rct229.rule_engine.rulesets import RuleSet
 from rct229.ruletest_engine.ruletest_jsons.scripts.excel_to_test_json_utilities import (
     generate_rule_test_dictionary,
 )


### PR DESCRIPTION
This PR addresses the ```Evaluation Process``` printout feature for the web development.

If the ```eval_proc_print``` argument is set to **True** in the ```run_ashrae9012019_tests``` function, evaluation process with 10% increments is printed out. Otherwise, the ```Processing Rule``` progress is printed out as was. Thanks!