### PR TITLE
Rule test engine bug fix - sometimes fail to flag not_applicable and undetermined

### DIFF
--- a/rct229/ruletest_engine/ruletest_engine.py
+++ b/rct229/ruletest_engine/ruletest_engine.py
@@ -158,13 +158,20 @@ def process_test_result(test_result, test_dict, test_id):
             outcome_text = "NOT_APPLICABLE"
 
     else:
+
+        expected_result = test_dict["expected_rule_outcome"]
+
         if test_result == "pass":
-            outcome_text = f"FAILURE: Test {test_id} passed unexpectedly. The following condition was not identified: {description}"
+            outcome_text = f"FAILURE: Test {test_id} passed unexpectedly. Expected '{expected_result}'. The following condition was not identified: {description}"
         elif test_result == "fail":
-            outcome_text = f"FAILURE: Test {test_id} failed unexpectedly. The following condition was not identified: {description}"
+            outcome_text = f"FAILURE: Test {test_id} failed unexpectedly. Expected '{expected_result}'. The following condition was not identified: {description}"
         elif test_result == "undetermined":
             outcome_text = (
-                f"FAILURE: Test {test_id} returned 'undetermined' unexpectedly."
+                f"FAILURE: Test {test_id} returned 'undetermined' unexpectedly. Expected '{expected_result}'."
+            )
+        elif test_result == "not_applicable":
+            outcome_text = (
+                f"FAILURE: Test {test_id} returned 'not_applicable' unexpectedly.  Expected '{expected_result}'."
             )
         else:
             outcome_text = (
@@ -252,7 +259,10 @@ def run_section_tests(test_json_name: str, ruleset_doc: RuleSet):
         test_result_dict[
             f"{test_id}"
         ] = []  # Initialize log of this tests multiple results
-        print_errors = False
+
+        # Flag determining if an error was found when running this specific rule test
+        test_error_found = False
+
         # Pull in rule, if written. If not found, fail the test and log which Section and Rule could not be found.
         try:
             rule = available_rule_definitions_dict[function_name]()
@@ -298,19 +308,29 @@ def run_section_tests(test_json_name: str, ruleset_doc: RuleSet):
                 outcome_structure, test_result_dict, test_dict, test_id
             )
 
-            # Check set of results for this test ID against expected outcome
-            if test_dict["expected_rule_outcome"] == "pass":
-                # For an expected pass, ALL tested elements in the RMR triplet must pass
-                if not all(test_result_dict[f"{test_id}"]):
-                    print_errors = True
+            match test_dict["expected_rule_outcome"]:
 
-            elif test_dict["expected_rule_outcome"] == "fail":
-                # If all elements don't meet the expected outcome, flag this as an error
-                if not any(test_result_dict[f"{test_id}"]):
-                    print_errors = True
+                case "pass":
+                    # For an expected pass, ALL tested elements in the RMR triplet must pass
+                    if not all(test_result_dict[f"{test_id}"]):
+                        test_error_found = True
+
+                case "fail" | "undetermined" | "not_applicable":
+                    # If all elements don't meet the expected outcome, flag this as an error
+                    # (e.g., every test_result_dict element is false with 'fail' as the expected outcome. At least
+                    #  one element must equal 'fail' for this to be a successful test)
+                    if not any(test_result_dict[f"{test_id}"]):
+                        test_error_found = True
+
+                case _:
+                    rule_outcome = test_dict["expected_rule_outcome"]
+                    # Print message communicating that a rule cannot be found
+                    print(f"RULE OUTCOME NOT FOUND: {rule_outcome} is not a valid rule outcome. Expected 'pass', 'fail',"
+                          f"'undetermined' or 'not_applicable'.")
+                    test_error_found = True
 
             # If errors were found, communicate the error logs
-            if print_errors:
+            if test_error_found:
                 all_tests_pass = False
 
                 # Print log of all errors


### PR DESCRIPTION
Addressed issue where `undetermined` and `not_applicable` tests would not get flagged if a ruletest section had exclusively failures of those type. NOTE-- this will result in needing to revisit test cases that passed when they should have failed.