### PR TITLE
Rule 19-19 raised messaged fix

### DIFF
--- a/rct229/rulesets/ashrae9012019/section19/section19rule19.py
+++ b/rct229/rulesets/ashrae9012019/section19/section19rule19.py
@@ -275,11 +275,11 @@ class Section19Rule19(RuleDefinitionListIndexedBase):
             more_than_one_supply_fan_b = calc_vals["more_than_one_supply_fan_b"]
 
             if more_than_one_supply_fan_b:
-                UNDERMINED_MSG = f"{hvac_id_b} has more than one supply fan associated with the HVAC system in the baseline and therefore this check could not be conducted for this HVAC sytem. Conduct manual check for compliance with G3.1.2.9."
+                UNDETERMINED_MSG = f"{hvac_id_b} has more than one supply fan associated with the HVAC system in the baseline and therefore this check could not be conducted for this HVAC sytem. Conduct manual check for compliance with G3.1.2.9."
             else:
-                UNDERMINED_MSG = f"{hvac_id_b} has zone(s) with non-mechanical cooling in the proposed design, conduct a manual check that the baseline building design includes a fan power allowance of <insert IP or SI version as applicable Pfan = CFMnmc × 0.054, where, CFMnmc = the baseline non-mechanical cooling fan airflow, cfm for the non-mechanical cooling fan in additional to the 0.3 W/CFM allowance for the HVAC system>."
+                UNDETERMINED_MSG = f"{hvac_id_b} has zone(s) with non-mechanical cooling in the proposed design, conduct a manual check that the baseline building design includes a fan power allowance of <insert IP or SI version as applicable Pfan = CFMnmc × 0.054, where, CFMnmc = the baseline non-mechanical cooling fan airflow, cfm for the non-mechanical cooling fan in additional to the 0.3 W/CFM allowance for the HVAC system>."
 
-            return UNDERMINED_MSG
+            return UNDETERMINED_MSG
 
         def rule_check(self, context, calc_vals=None, data=None):
             zones_served_by_hvac_has_non_mech_cooling_bool_p = calc_vals[
@@ -297,7 +297,7 @@ class Section19Rule19(RuleDefinitionListIndexedBase):
                     fan_power_per_flow_b,
                     REQ_FAN_POWER_FLOW_RATIO,
                 )
-            ) or (fan_power_per_flow_b < REQ_FAN_POWER_FLOW_RATIO)
+            )
 
         def is_tolerance_fail(self, context, calc_vals=None, data=None):
             zones_served_by_hvac_has_non_mech_cooling_bool_p = calc_vals[

--- a/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section19/rule_19_19.json
+++ b/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section19/rule_19_19.json
@@ -25,15 +25,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -85,15 +82,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -168,7 +162,6 @@
         "Test": "b",
         "test_description": "The project has one building segment with one zone served by a baseline system type 10. The system has one of each of a supply, return, exhaust, and relief fan as well as a zonal exhaust fan. Each of the 5 fans has 80 W design electric power for a total of 400 W with 800 cfm of design supply airflow.",
         "expected_rule_outcome": "fail",
-        "expected_raised_message_includes": "fails with a conservative outcome. The fan power airflow (W/cfm) for",
         "standard": {
             "rule_id": "19-19",
             "ruleset_reference": "G3.1.2.9",
@@ -189,15 +182,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -248,15 +238,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -351,15 +338,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -410,15 +394,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -519,15 +500,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -579,15 +557,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "Air Terminal",
@@ -640,6 +615,162 @@
                                                             "id": "Exhaust fan 1",
                                                             "specification_method": "SIMPLE",
                                                             "design_electric_power": 60
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": "BASELINE_0"
+                    }
+                ]
+            }
+        }
+    },
+    "rule-19-19-e": {
+        "Section": 19,
+        "Rule": 19,
+        "Test": "e",
+        "test_description": "The project has one building segment with one zone served by a baseline system type 10. The system has one of each of a supply, return, exhaust, and relief fan as well as a zonal exhaust fan. Each of the 5 fans has 80 W design electric power for a total of 400 W with 800 cfm of design supply airflow.",
+        "expected_rule_outcome": "fail",
+        "expected_raised_message_includes": "fails with a conservative outcome. The fan power airflow (W/cfm) for",
+        "standard": {
+            "rule_id": "19-19",
+            "ruleset_reference": "G3.1.2.9",
+            "rule_description": "For baseline systems 9 and 10 the system fan electrical power (Pfan) for supply, return, exhaust, and relief shall be CFMs \u00d7 0.3, where, CFMs = the baseline system maximum design supply fan airflow rate, cfm. If modeling a non-mechanical cooling fan is required by Section G3.1.2.8.2, there is a fan power allowance of Pfan = CFMnmc \u00d7 0.054, where, CFMnmc = the baseline non-mechanical cooling fan airflow, cfm for the non-mechanical cooling. ",
+            "applicable_rmd": "Baseline RMD",
+            "rule_assertion": "=",
+            "comparison_value": "Expected Value",
+            "primary_rule": "Full",
+            "schema_version": "0.0.36"
+        },
+        "rmd_transformations": {
+            "proposed": {
+                "id": "ASHRAE229 1",
+                "data_timestamp": "2024-02-12T09:00Z",
+                "ruleset_model_descriptions": [
+                    {
+                        "id": "RMD 1",
+                        "buildings": [
+                            {
+                                "id": "Building 1",
+                                "building_segments": [
+                                    {
+                                        "id": "Building Segment 1",
+                                        "zones": [
+                                            {
+                                                "id": "Thermal Zone 1",
+                                                "terminals": [
+                                                    {
+                                                        "id": "Air Terminal",
+                                                        "is_supply_ducted": true,
+                                                        "type": "CONSTANT_AIR_VOLUME",
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
+                                                        "heating_source": "ELECTRIC",
+                                                        "fan": {
+                                                            "id": "Terminal Fan 1"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "heating_ventilating_air_conditioning_systems": [
+                                            {
+                                                "id": "System 10",
+                                                "fan_system": {
+                                                    "id": "CAV Fan System 1",
+                                                    "fan_control": "CONSTANT",
+                                                    "supply_fans": [
+                                                        {
+                                                            "id": "Supply Fan 1"
+                                                        }
+                                                    ],
+                                                    "return_fans": [
+                                                        {
+                                                            "id": "Return Fan 1"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": "PROPOSED"
+                    }
+                ]
+            },
+            "baseline": {
+                "id": "ASHRAE229 1",
+                "data_timestamp": "2024-02-12T09:00Z",
+                "ruleset_model_descriptions": [
+                    {
+                        "id": "RMD 1",
+                        "buildings": [
+                            {
+                                "id": "Building 1",
+                                "building_segments": [
+                                    {
+                                        "id": "Building Segment 1",
+                                        "zones": [
+                                            {
+                                                "id": "Thermal Zone 1",
+                                                "terminals": [
+                                                    {
+                                                        "id": "Air Terminal",
+                                                        "is_supply_ducted": true,
+                                                        "type": "CONSTANT_AIR_VOLUME",
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
+                                                        "heating_source": "ELECTRIC",
+                                                        "fan": {
+                                                            "id": "Terminal Fan 1"
+                                                        }
+                                                    }
+                                                ],
+                                                "zonal_exhaust_fan": {
+                                                    "id": "Zone exhaust fan 1",
+                                                    "specification_method": "SIMPLE",
+                                                    "design_electric_power": 80
+                                                }
+                                            }
+                                        ],
+                                        "heating_ventilating_air_conditioning_systems": [
+                                            {
+                                                "id": "System 10",
+                                                "fan_system": {
+                                                    "id": "CAV Fan System 1",
+                                                    "fan_control": "CONSTANT",
+                                                    "supply_fans": [
+                                                        {
+                                                            "id": "Supply Fan 1",
+                                                            "specification_method": "SIMPLE",
+                                                            "design_electric_power": 80,
+                                                            "design_airflow": 755.1159091199997
+                                                        }
+                                                    ],
+                                                    "return_fans": [
+                                                        {
+                                                            "id": "Return fan 1",
+                                                            "specification_method": "SIMPLE",
+                                                            "design_electric_power": 80
+                                                        }
+                                                    ],
+                                                    "relief_fans": [
+                                                        {
+                                                            "id": "Relief fan 1",
+                                                            "specification_method": "SIMPLE",
+                                                            "design_electric_power": 80
+                                                        }
+                                                    ],
+                                                    "exhaust_fans": [
+                                                        {
+                                                            "id": "Exhaust fan 1",
+                                                            "specification_method": "SIMPLE",
+                                                            "design_electric_power": 80
                                                         }
                                                     ]
                                                 }

--- a/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section19/rule_19_19.json
+++ b/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section19/rule_19_19.json
@@ -193,11 +193,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ]
                                             }
@@ -205,6 +201,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -249,11 +250,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ],
                                                 "zonal_exhaust_fan": {
@@ -266,6 +263,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -349,11 +351,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ]
                                             }
@@ -361,6 +359,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -405,11 +408,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ],
                                                 "zonal_exhaust_fan": {
@@ -422,6 +421,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -511,11 +515,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ],
                                                 "non_mechanical_cooling_fan_airflow": 117.98686079999996
@@ -524,6 +524,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -568,11 +573,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ],
                                                 "zonal_exhaust_fan": {
@@ -585,6 +586,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -634,7 +640,7 @@
         "Section": 19,
         "Rule": 19,
         "Test": "e",
-        "test_description": "The project has one building segment with one zone served by a baseline system type 10. The system has one of each of a supply, return, exhaust, and relief fan as well as a zonal exhaust fan. Each of the 5 fans has 80 W design electric power for a total of 400 W with 800 cfm of design supply airflow.",
+        "test_description": "The project has one building segment with one zone served by a baseline system type 10. The system has one of each of a supply, return, exhaust, and relief fan as well as a zonal exhaust fan. Each of the 5 fans has 80 W design electric power for a total of 400 W with 2000 cfm of design supply airflow.",
         "expected_rule_outcome": "fail",
         "expected_raised_message_includes": "fails with a conservative outcome. The fan power airflow (W/cfm) for",
         "standard": {
@@ -668,11 +674,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ]
                                             }
@@ -680,6 +682,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -724,11 +731,7 @@
                                                         "id": "Air Terminal",
                                                         "is_supply_ducted": true,
                                                         "type": "CONSTANT_AIR_VOLUME",
-                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10",
-                                                        "heating_source": "ELECTRIC",
-                                                        "fan": {
-                                                            "id": "Terminal Fan 1"
-                                                        }
+                                                        "served_by_heating_ventilating_air_conditioning_system": "System 10"
                                                     }
                                                 ],
                                                 "zonal_exhaust_fan": {
@@ -741,6 +744,11 @@
                                         "heating_ventilating_air_conditioning_systems": [
                                             {
                                                 "id": "System 10",
+                                                "heating_system": {
+                                                    "id": "Furnace Coil 1",
+                                                    "type": "ELECTRIC_RESISTANCE",
+                                                    "energy_source_type": "ELECTRICITY"
+                                                },
                                                 "fan_system": {
                                                     "id": "CAV Fan System 1",
                                                     "fan_control": "CONSTANT",
@@ -749,7 +757,7 @@
                                                             "id": "Supply Fan 1",
                                                             "specification_method": "SIMPLE",
                                                             "design_electric_power": 80,
-                                                            "design_airflow": 755.1159091199997
+                                                            "design_airflow": 943.8948863999997
                                                         }
                                                     ],
                                                     "return_fans": [


### PR DESCRIPTION
Addressed issue in 19-19 where if the W/CFM would pass if it was below the expected value. Now it correctly fails for < 0.3 W/CFM as well, but correctly raises the appropriate message from get_fail_msg. 19-19b is for W/CFM > 0.3 and the new 19-19e is for W/CFM < 0.3