### PR TITLE
Rule 19-35 raised messaged fix

### DIFF
--- a/rct229/rulesets/ashrae9012019/section19/section19rule35.py
+++ b/rct229/rulesets/ashrae9012019/section19/section19rule35.py
@@ -81,13 +81,28 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
                         f'$.buildings[*].building_segments[*].zones[*][?(@.id="{zone_id_b}")].spaces[*].lighting_space_type',
                         rmd_b,
                     )
+
+                    # Count this zone's spaces and the number of light space types
+                    space_count = len(
+                        find_all(
+                            f'$.buildings[*].building_segments[*].zones[*][?(@.id="{zone_id_b}")].spaces[*]',
+                            rmd_b,
+                        )
+                    )
+                    lighting_space_type_count = len(lighting_space_types_b)
+
+                    # Evaluate is all of this zone's lighting space types are defined (i.e., does each space have
+                    # an associated lighting space type)
+                    all_zone_types_defined = space_count == lighting_space_type_count
+
                     all_lighting_space_types_defined = (
-                        all(lighting_space_types_b) and all_lighting_space_types_defined
+                        all(lighting_space_types_b)
+                        and all_zone_types_defined
+                        and all_lighting_space_types_defined
                     )
                     are_any_lighting_space_types_defined = (
-                        any(lighting_space_types_b)
-                        or are_any_lighting_space_types_defined
-                    )
+                        any(lighting_space_types_b) or lighting_space_type_count > 0
+                    ) or are_any_lighting_space_types_defined
                     hvac_system_serves_only_labs = (
                         all(
                             map(
@@ -96,8 +111,8 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
                                 lighting_space_types_b,
                             )
                         )
-                        and hvac_system_serves_only_labs
-                    )
+                        and lighting_space_type_count > 0
+                    ) and hvac_system_serves_only_labs
 
                     zone_OA_flow_list_of_schedules_b.append(
                         get_min_oa_cfm_sch_zone(rmd_b, zone_id_b, leap_year_b)

--- a/rct229/rulesets/ashrae9012019/section19/section19rule35.py
+++ b/rct229/rulesets/ashrae9012019/section19/section19rule35.py
@@ -66,6 +66,7 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
             )
 
             hvac_system_serves_only_labs = True
+            hvac_system_serves_no_space_types = True
             are_any_lighting_space_types_defined = False
             all_lighting_space_types_defined = True
             zone_OA_flow_list_of_schedules_b = []
@@ -95,6 +96,10 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
                     # an associated lighting space type)
                     all_zone_types_defined = space_count == lighting_space_type_count
 
+                    # If no space types are served, this is valuable for undetermined checks
+                    hvac_system_serves_no_space_types = (len(lighting_space_types_b) == 0 and
+                                                         hvac_system_serves_no_space_types)
+
                     all_lighting_space_types_defined = (
                         all(lighting_space_types_b)
                         and all_zone_types_defined
@@ -110,9 +115,9 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
                                 == LIGHTING_SPACE.LABORATORY_EXCEPT_IN_OR_AS_A_CLASSROOM,
                                 lighting_space_types_b,
                             )
-                        )
-                        and lighting_space_type_count > 0
+                        ) and not hvac_system_serves_no_space_types
                     ) and hvac_system_serves_only_labs
+
 
                     zone_OA_flow_list_of_schedules_b.append(
                         get_min_oa_cfm_sch_zone(rmd_b, zone_id_b, leap_year_b)
@@ -138,6 +143,7 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
             return {
                 "dict_of_zones_and_terminal_units_served_by_hvac_sys_b": dict_of_zones_and_terminal_units_served_by_hvac_sys_b,
                 "hvac_system_serves_only_labs": hvac_system_serves_only_labs,
+                "hvac_system_serves_no_space_types": hvac_system_serves_no_space_types,
                 "are_any_lighting_space_types_defined": are_any_lighting_space_types_defined,
                 "all_lighting_space_types_defined": all_lighting_space_types_defined,
                 "modeled_baseline_total_zone_min_OA_flow": modeled_baseline_total_zone_min_OA_flow,
@@ -154,6 +160,7 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
 
             def is_applicable(self, context, data=None):
                 hvac_system_serves_only_labs = data["hvac_system_serves_only_labs"]
+                hvac_system_serves_no_space_types = data["hvac_system_serves_no_space_types"]
                 modeled_baseline_total_zone_min_OA_flow = data[
                     "modeled_baseline_total_zone_min_OA_flow"
                 ]
@@ -162,7 +169,7 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
                 ]
 
                 return (
-                    hvac_system_serves_only_labs
+                    (hvac_system_serves_only_labs or hvac_system_serves_no_space_types)
                     and modeled_baseline_total_zone_min_OA_flow
                     > modeled_proposed_total_zone_min_OA_flow
                 )
@@ -181,19 +188,22 @@ class Section19Rule35(RuleDefinitionListIndexedBase):
                 are_any_lighting_space_types_defined = data[
                     "are_any_lighting_space_types_defined"
                 ]
+                hvac_system_serves_no_space_types = data[
+                    "hvac_system_serves_no_space_types"
+                ]
 
                 return (
                     modeled_baseline_total_zone_min_OA_flow
                     > modeled_proposed_total_zone_min_OA_flow
                 ) and (
                     (
-                        hvac_system_serves_only_labs
+                            hvac_system_serves_only_labs
                         and (
                             all_lighting_space_types_defined
                             or are_any_lighting_space_types_defined
                         )
                     )
-                    or not are_any_lighting_space_types_defined
+                    or hvac_system_serves_no_space_types
                 )
 
             def get_manual_check_required_msg(self, context, calc_vals=None, data=None):

--- a/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section19/rule_19_35.json
+++ b/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section19/rule_19_35.json
@@ -26,15 +26,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -60,8 +57,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",
@@ -8945,15 +8940,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -8979,8 +8971,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",
@@ -17882,15 +17872,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -17912,8 +17899,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",
@@ -26797,15 +26782,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -26830,8 +26812,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",
@@ -35733,15 +35713,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -35762,8 +35739,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",
@@ -44620,15 +44595,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -44652,8 +44624,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",
@@ -53527,15 +53497,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -53561,8 +53528,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",
@@ -62419,15 +62384,12 @@
                         "buildings": [
                             {
                                 "id": "Building 1",
-                                "building_open_schedule": "Required Building Schedule 1",
                                 "building_segments": [
                                     {
                                         "id": "Building Segment 1",
                                         "zones": [
                                             {
                                                 "id": "Thermal Zone 1",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 1",
@@ -62453,8 +62415,6 @@
                                             },
                                             {
                                                 "id": "Thermal Zone 2",
-                                                "thermostat_cooling_setpoint_schedule": "Required Cooling Schedule 1",
-                                                "thermostat_heating_setpoint_schedule": "Required Heating Schedule 1",
                                                 "terminals": [
                                                     {
                                                         "id": "VAV Air Terminal 2",


### PR DESCRIPTION
Error found in the create_data function for 19-35. The parameter all_lighting_space_types_defined is set to true but never evaluated. This logic fails to identify that one of the spaces in the baseline RMI is missing a lighting_space_type.  Likewise, a fix was needed for checking the are_any_lighting_space_types_defined parameter.