### PR TITLE
Rule 1-1 raised message fix

### DIFF
--- a/rct229/rulesets/ashrae9012019/section1/section1rule1.py
+++ b/rct229/rulesets/ashrae9012019/section1/section1rule1.py
@@ -116,10 +116,19 @@ class Section1Rule1(RuleDefinitionListIndexedBase):
                     bpf_bat_dict_area = bpf_building_area_type_dict[bpf_bat]["area"]
                     total_area += bpf_bat_dict_area
                     bpf_bat_sum_prod += expected_bpf * bpf_bat_dict_area
+
+            # Checks if only undetermined was returned. If so, skip check for total area.
+            only_undetermined = (
+                len(bpf_building_area_type_dict) == 1
+                and "UNDETERMINED" in bpf_building_area_type_dict
+            )
+
+            if not only_undetermined:
                 assert_(
                     total_area > 0,
                     "The `total_area ` value must be greater than 0.",
                 )
+
             return {
                 "output_bpf_list": output_bpf_list,
                 "bpf_bat_sum_prod": bpf_bat_sum_prod,


### PR DESCRIPTION
Fixed: Issue where section 1 rule 1 would throw where total building area would equal 0 if only UNDETERMINED was returned in check. This happens if BAT's were exclusively oddball ones like restroom. A total area of 0 would throw a different message about the floor area when the issue had to do with the BAT.  Added an exception for these cases to correctly communicate the source of the error.