### PR TITLE
Addressing issue 1652 - Unregulated Subsurface returning undetermined

### DIFF
--- a/rct229/rulesets/ashrae9012019/section5/section5rule21.py
+++ b/rct229/rulesets/ashrae9012019/section5/section5rule21.py
@@ -10,7 +10,6 @@ from rct229.rulesets.ashrae9012019.ruleset_functions.get_surface_conditioning_ca
 )
 from rct229.utils.pint_utils import CalcQ
 
-
 FAIL_MSG = "Subsurface that is not regulated (Not part of building envelope) is not modeled with the same area, U-factor and SHGC in the baseline as in the propsoed design."
 
 
@@ -63,7 +62,10 @@ class Section5Rule21(RuleDefinitionListIndexedBase):
         def list_filter(self, context_item, data=None):
             surface_b = context_item.BASELINE_0
 
-            return data["scc_dict_b"][surface_b["id"]] == SCC.UNREGULATED
+            return (
+                data["scc_dict_b"][surface_b["id"]] == SCC.UNREGULATED
+                and len(surface_b.get("subsurfaces", [])) > 0
+            )
 
         class UnregulatedSurfaceRule(RuleDefinitionListIndexedBase):
             def __init__(self):

--- a/rct229/rulesets/ashrae9012019/section5/section5rule22.py
+++ b/rct229/rulesets/ashrae9012019/section5/section5rule22.py
@@ -71,6 +71,7 @@ class Section5Rule22(RuleDefinitionListIndexedBase):
             return (
                 get_opaque_surface_type(surface_b) == OST.ABOVE_GRADE_WALL
                 and data["scc_dict_b"][surface_b["id"]] != SCC.UNREGULATED
+                and len(surface_b.get("subsurfaces", [])) > 0
             )
 
         class AboveGradeWallRule(RuleDefinitionListIndexedBase):

--- a/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section5/rule_5_21.json
+++ b/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section5/rule_5_21.json
@@ -685,5 +685,156 @@
                 ]
             }
         }
+    },
+    "rule-5-21-e": {
+        "Section": 5,
+        "Rule": 21,
+        "Test": "e",
+        "test_description": "Project has one building segment and includes a space with an unregulated above-grade wall surface but no windows or other subsurfaces. ",
+        "expected_rule_outcome": "not_applicable",
+        "standard": {
+            "rule_id": "5-21",
+            "ruleset_reference": "Table G3.1(1), Baseline Building Performance",
+            "rule_description": "Fenestration that is not regulated (not part of building envelope) must be modeled with the same area, U-factor and SHGC in the baseline as in the proposed design",
+            "applicable_rmr": "Baseline Model",
+            "rule_assertion": "=",
+            "comparison_value": "Proposed Model",
+            "primary_rule": "Full",
+            "schema_version": "0.1.3"
+        },
+        "rmd_transformations": {
+            "proposed": {
+                "id": "RPD 1",
+                "ruleset_model_descriptions": [
+                    {
+                        "weather": {
+                            "climate_zone": "CZ4A",
+                            "data_source_type": "OTHER"
+                        },
+                        "id": "RMD 1",
+                        "buildings": [
+                            {
+                                "id": "Building 1",
+                                "building_segments": [
+                                    {
+                                        "id": "Building Segment 1",
+                                        "zones": [
+                                            {
+                                                "id": "Zone 1",
+                                                "volume": 21.237634943999996,
+                                                "spaces": [
+                                                    {
+                                                        "id": "Space 1",
+                                                        "floor_area": 23.225759999999998
+                                                    }
+                                                ],
+                                                "terminals": [
+                                                    {
+                                                        "id": "Terminal 1",
+                                                        "served_by_heating_ventilating_air_conditioning_system": "HVAC 1"
+                                                    }
+                                                ],
+                                                "surfaces": [
+                                                    {
+                                                        "id": "Surface 1",
+                                                        "adjacent_to": "EXTERIOR",
+                                                        "tilt": 90,
+                                                        "area": 92.90303999999999,
+                                                        "construction": {
+                                                            "id": "Construction 1",
+                                                            "u_factor": 3.2366105565544463
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "heating_ventilating_air_conditioning_systems": [
+                                            {
+                                                "id": "HVAC 1",
+                                                "cooling_system": {
+                                                    "id": "Cooling System 1",
+                                                    "design_sensible_cool_capacity": 0.0
+                                                },
+                                                "heating_system": {
+                                                    "id": "Heating System 1",
+                                                    "design_capacity": 0.0
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": "PROPOSED"
+                    }
+                ]
+            },
+            "baseline": {
+                "id": "RPD 1",
+                "ruleset_model_descriptions": [
+                    {
+                        "weather": {
+                            "climate_zone": "CZ4A",
+                            "data_source_type": "OTHER"
+                        },
+                        "id": "RMD 1",
+                        "buildings": [
+                            {
+                                "id": "Building 1",
+                                "building_segments": [
+                                    {
+                                        "id": "Building Segment 1",
+                                        "zones": [
+                                            {
+                                                "id": "Zone 1",
+                                                "volume": 21.237634943999996,
+                                                "spaces": [
+                                                    {
+                                                        "id": "Space 1",
+                                                        "floor_area": 23.225759999999998
+                                                    }
+                                                ],
+                                                "terminals": [
+                                                    {
+                                                        "id": "Terminal 1",
+                                                        "served_by_heating_ventilating_air_conditioning_system": "HVAC 1"
+                                                    }
+                                                ],
+                                                "surfaces": [
+                                                    {
+                                                        "id": "Surface 1",
+                                                        "adjacent_to": "EXTERIOR",
+                                                        "tilt": 90,
+                                                        "area": 92.90303999999999,
+                                                        "construction": {
+                                                            "id": "Construction 1",
+                                                            "u_factor": 3.2366105565544463
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "heating_ventilating_air_conditioning_systems": [
+                                            {
+                                                "id": "HVAC 1",
+                                                "cooling_system": {
+                                                    "id": "Cooling System 1",
+                                                    "design_sensible_cool_capacity": 0.0
+                                                },
+                                                "heating_system": {
+                                                    "id": "Heating System 1",
+                                                    "design_capacity": 0.0
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": "BASELINE_0"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section5/rule_5_22.json
+++ b/rct229/ruletest_engine/ruletest_jsons/ashrae9012019/section5/rule_5_22.json
@@ -290,5 +290,90 @@
                 ]
             }
         }
+    },
+    "rule-5-22-d": {
+        "Section": 5,
+        "Rule": 22,
+        "Test": "d",
+        "test_description": "Project has one building segment and includes a space with an unregulated above-grade wall surface but no windows or other subsurfaces. ",
+        "expected_rule_outcome": "not_applicable",
+        "standard": {
+            "rule_id": "5-22",
+            "ruleset_reference": "Table G3.1(5) Baseline Building Performance(d)",
+            "rule_description": "Baseline vertical fenestration shall be assumed to be flush with the exterior wall, and no shading projections shall be modeled.",
+            "applicable_rmr": "Baseline Model",
+            "rule_assertion": "=",
+            "comparison_value": "Expected Value",
+            "primary_rule": "Full",
+            "schema_version": "0.1.3"
+        },
+        "rmd_transformations": {
+            "baseline": {
+                "id": "RPD 1",
+                "ruleset_model_descriptions": [
+                    {
+                        "weather": {
+                            "climate_zone": "CZ4A",
+                            "data_source_type": "OTHER"
+                        },
+                        "id": "RMD 1",
+                        "buildings": [
+                            {
+                                "id": "Building 1",
+                                "building_segments": [
+                                    {
+                                        "id": "Building Segment 1",
+                                        "zones": [
+                                            {
+                                                "id": "Zone 1",
+                                                "volume": 21.237634943999996,
+                                                "spaces": [
+                                                    {
+                                                        "id": "Space 1",
+                                                        "floor_area": 23.225759999999998
+                                                    }
+                                                ],
+                                                "terminals": [
+                                                    {
+                                                        "id": "Terminal 1",
+                                                        "served_by_heating_ventilating_air_conditioning_system": "HVAC 1"
+                                                    }
+                                                ],
+                                                "surfaces": [
+                                                    {
+                                                        "id": "Surface 1",
+                                                        "adjacent_to": "EXTERIOR",
+                                                        "tilt": 90,
+                                                        "area": 92.90303999999999,
+                                                        "construction": {
+                                                            "id": "Construction 1",
+                                                            "u_factor": 3.2366105565544463
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "heating_ventilating_air_conditioning_systems": [
+                                            {
+                                                "id": "HVAC 1",
+                                                "cooling_system": {
+                                                    "id": "Cooling System 1",
+                                                    "design_sensible_cool_capacity": 0.0
+                                                },
+                                                "heating_system": {
+                                                    "id": "Heating System 1",
+                                                    "design_capacity": 0.0
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": "BASELINE_0"
+                    }
+                ]
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR addresses [issue 1652](https://github.com/pnnl/ruleset-checking-tool/issues/1652). Unregulated subsurfaces should now return a `not_applicable` instead of `undetermined` outcome for rules 5-21 and 5-22.