### PR TITLE
RCT/JDJ/18-1 calc vals

### DIFF
--- a/rct229/rulesets/ashrae9012019/section18/section18rule1.py
+++ b/rct229/rulesets/ashrae9012019/section18/section18rule1.py
@@ -155,8 +155,13 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                 )
 
                 hvac_system_types_serving_zone_b = [
-                    system_type_str for system_type_str, system_list in data["baseline_hvac_system_dict_b"].items()
-                    if any(sys_b in system_list for sys_b in hvac_systems_serving_zone_b)
+                    system_type_str
+                    for system_type_str, system_list in data[
+                        "baseline_hvac_system_dict_b"
+                    ].items()
+                    if any(
+                        sys_b in system_list for sys_b in hvac_systems_serving_zone_b
+                    )
                 ]
 
                 return {

--- a/rct229/rulesets/ashrae9012019/section18/section18rule1.py
+++ b/rct229/rulesets/ashrae9012019/section18/section18rule1.py
@@ -154,8 +154,14 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                     ]
                 )
 
+                hvac_system_types_serving_zone_b = [
+                    system_type_str for system_type_str, system_list in data["baseline_hvac_system_dict_b"].items()
+                    if any(sys_b in system_list for sys_b in hvac_systems_serving_zone_b)
+                ]
+
                 return {
                     "is_system_part_of_expected_sys_type_b": is_system_part_of_expected_sys_type_b,
+                    "hvac_system_types_serving_zone_b": hvac_system_types_serving_zone_b,
                     "expected_system_type_b": expected_system_type_b,
                 }
 

--- a/rct229/rulesets/ashrae9012019/section18/section18rule1.py
+++ b/rct229/rulesets/ashrae9012019/section18/section18rule1.py
@@ -142,7 +142,13 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                 hvac_systems_serving_zone_b = data["hvac_systems_serving_zone_b"][
                     zone_id_b
                 ]
-
+                hvac_system_types_b = {
+                    system_type: system_list
+                    for system_type, system_list in data[
+                        "baseline_hvac_system_dict_b"
+                    ].items()
+                    if system_list
+                }
                 hvac_system_types_serving_zone_b = [
                     system_type_str
                     for system_type_str, system_list in data[
@@ -154,6 +160,7 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                 ]
 
                 return {
+                    "hvac_system_types_b": hvac_system_types_b,
                     "hvac_system_types_serving_zone_b": hvac_system_types_serving_zone_b,
                     "expected_system_type_b": expected_system_type_b,
                 }

--- a/rct229/rulesets/ashrae9012019/section18/section18rule1.py
+++ b/rct229/rulesets/ashrae9012019/section18/section18rule1.py
@@ -155,7 +155,8 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                 )
 
                 return {
-                    "is_system_part_of_expected_sys_type_b": is_system_part_of_expected_sys_type_b
+                    "is_system_part_of_expected_sys_type_b": is_system_part_of_expected_sys_type_b,
+                    "expected_system_type_b": expected_system_type_b,
                 }
 
             def manual_check_required(self, context, calc_vals=None, data=None):

--- a/rct229/rulesets/ashrae9012019/section18/section18rule1.py
+++ b/rct229/rulesets/ashrae9012019/section18/section18rule1.py
@@ -142,17 +142,6 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                 hvac_systems_serving_zone_b = data["hvac_systems_serving_zone_b"][
                     zone_id_b
                 ]
-                systems_of_expected_type_list_b = data["baseline_hvac_system_dict_b"][
-                    expected_system_type_b
-                ]
-
-                # any HVAC system serving this zone is in the `systems_of_expected_type_list_b`
-                is_system_part_of_expected_sys_type_b = any(
-                    [
-                        sys_b in systems_of_expected_type_list_b
-                        for sys_b in hvac_systems_serving_zone_b
-                    ]
-                )
 
                 hvac_system_types_serving_zone_b = [
                     system_type_str
@@ -165,7 +154,6 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                 ]
 
                 return {
-                    "is_system_part_of_expected_sys_type_b": is_system_part_of_expected_sys_type_b,
                     "hvac_system_types_serving_zone_b": hvac_system_types_serving_zone_b,
                     "expected_system_type_b": expected_system_type_b,
                 }
@@ -225,11 +213,12 @@ class Section18Rule1(RuleDefinitionListIndexedBase):
                 return advisory_note
 
             def rule_check(self, context, calc_vals=None, data=None):
-                is_system_part_of_expected_sys_type_b = calc_vals[
-                    "is_system_part_of_expected_sys_type_b"
+                hvac_system_types_serving_zone_b = calc_vals[
+                    "hvac_system_types_serving_zone_b"
                 ]
+                expected_system_type_b = calc_vals["expected_system_type_b"]
 
-                return is_system_part_of_expected_sys_type_b
+                return expected_system_type_b in hvac_system_types_serving_zone_b
 
             def get_fail_msg(self, context, calc_vals=None, data=None):
                 zone_b = context.BASELINE_0


### PR DESCRIPTION
We would like to be able to use the expected_system_type determined in rule 18-1 for reporting