### PR TITLE
Highlight Precision Comparison Rounding Issues

### DIFF
--- a/rct229/utils/std_comparisons_test.py
+++ b/rct229/utils/std_comparisons_test.py
@@ -13,6 +13,7 @@ from rct229.utils.std_comparisons import (
 )
 
 _M2 = ureg("m2")
+_TONS = ureg("tons")
 
 
 def test__std_equal__true_with_units():
@@ -192,6 +193,10 @@ def test__std_equal_with_precision__10_false_with_units():
 
 def test__std_equal_with_precision__10_false_without_units():
     assert not std_equal_with_precision(155, 150, 10)
+
+
+def test__std_equal_with_precision__1_true_with_units():
+    assert std_equal_with_precision(19.47 * _TONS, 19.452 * _TONS, 1 * _TONS)
 
 
 def test__std_conservative_outcome__true_with_units_gt():

--- a/rct229/utils/std_comparisons_test.py
+++ b/rct229/utils/std_comparisons_test.py
@@ -196,7 +196,7 @@ def test__std_equal_with_precision__10_false_without_units():
 
 
 def test__std_equal_with_precision__1_true_with_units():
-    assert std_equal_with_precision(19.47 * _TONS, 19.452 * _TONS, 1 * _TONS)
+    assert std_equal_with_precision(19.47 * _TONS, 19.52 * _TONS, 1 * _TONS)
 
 
 def test__std_conservative_outcome__true_with_units_gt():


### PR DESCRIPTION
@jugonzal07 @yunjoonjung-PNNL This example I think demonstrates what you were saying via email. I am fully in favor of reverting to the way I had hoped to develop this originally in [this commit](https://github.com/pnnl/ruleset-checking-tool/pull/1350/commits/29f29cdb133c3088faf796f6d53203cceaaba052) - but the current behavior is the intended behavior where values are rounded to some magnitude then compared.


