### PR TITLE
RCT/JDJ/reporting bugfixes

### DIFF
--- a/rct229/reports/ashrae9012019/ashrae901_2019_detail_report.py
+++ b/rct229/reports/ashrae9012019/ashrae901_2019_detail_report.py
@@ -75,7 +75,10 @@ class ASHRAE9012019DetailReport(RCTReport):
                     output_outcome_dict[RCTOutcomeLabel.UNDETERMINED] += 1
                 if outcome_label == RCTOutcomeLabel.NOT_APPLICABLE:
                     output_outcome_dict[RCTOutcomeLabel.NOT_APPLICABLE] += 1
-                evaluation_outcome["data_group_id"] = output_result["id"]
+                if "data_group_id" in output_result:
+                    evaluation_outcome["data_group_id"] = output_result["data_group_id"]
+                else:
+                    evaluation_outcome["data_group_id"] = output_result["id"]
                 evaluation_outcome["outcome"] = outcome_label
                 evaluation_outcome["messages"] = (
                     output_result["message"]

--- a/rct229/reports/ashrae9012022/__init__.py
+++ b/rct229/reports/ashrae9012022/__init__.py
@@ -1,11 +1,6 @@
-# Add all available rule modules in __all__
 import importlib
 
-__all__ = [
-    "section12rule5",
-]
-
-SHORT_NAME = "REC"
+__all__ = ["ashrae901_2019_summary_report", "ashrae901_2019_detail_report"]
 
 
 def __getattr__(name):

--- a/rct229/reports/ashrae9012022/__init__.py
+++ b/rct229/reports/ashrae9012022/__init__.py
@@ -1,6 +1,6 @@
 import importlib
 
-__all__ = ["ashrae901_2019_summary_report", "ashrae901_2019_detail_report"]
+__all__ = ["ashrae901_2022_summary_report", "ashrae901_2022_detail_report"]
 
 
 def __getattr__(name):

--- a/rct229/reports/ashrae9012022/ashrae901_2022_detail_report.py
+++ b/rct229/reports/ashrae9012022/ashrae901_2022_detail_report.py
@@ -1,0 +1,99 @@
+import json
+from copy import deepcopy
+
+from rct229.report_engine.rct_report import RCTReport
+from rct229.reports.utils import calc_vals_converter
+from rct229.rule_engine.rct_outcome_label import RCTOutcomeLabel
+
+
+class ASHRAE9012022DetailReport(RCTReport):
+    def __init__(self):
+        super(ASHRAE9012022DetailReport, self).__init__()
+        self.title = "ASHRAE STD 229P RULESET CHECKING TOOL"
+        self.purpose = "Project Testing Report"
+        self.ruleset = "ASHRAE 90.1-2022 Performance Rating Method (Appendix G)"
+        self.ruleset_report_file = f"{self.__class__.__name__}.json"
+
+    def initialize_ruleset_report(self, rule_outcome=None):
+        report_json = {}
+        report_json["title"] = self.title
+        report_json["purpose"] = self.purpose
+        report_json["tool_name"] = self.tool
+        report_json["tool_version"] = self.version
+        report_json["ruleset"] = self.ruleset
+        report_json["date_run"] = self.date_run
+        report_json["schema_version"] = self.schema_version
+        report_json["rpd_files"] = rule_outcome.get("rpd_files")
+        report_json["rules"] = []
+        return report_json
+
+    def generate_rule_report(self, rule_outcome, outcome_dict):
+        # set up the rule metadata
+        rule_id = rule_outcome["id"]
+        rule_report = {}
+        rule_report["rule_id"] = rule_id
+        rule_report["description"] = rule_outcome["description"]
+        rule_report["evaluation_type"] = (
+            "FULL" if rule_outcome["primary_rule"] else "APPLICABILITY"
+        )
+        rule_report["standard_section"] = rule_outcome["standard_section"]
+        rule_report["data_group_names"] = []
+        rule_report_list = []
+        self._rule_outcome_helper(rule_outcome, rule_report_list, outcome_dict)
+        rule_report["evaluations"] = rule_report_list
+        return rule_report
+
+    def add_rule_to_ruleset_report(self, ruleset_report, rule_report, rule_outcome):
+        # rule_report["rule_evaluation_outcome"] = rule_outcome
+        ruleset_report["rules"].append(deepcopy(rule_report))
+
+    def save_ruleset_report(self, ruleset_report, report_dir):
+        with open(report_dir, "w") as output_report:
+            output_report.write(json.dumps(ruleset_report, indent=4))
+
+    def _rule_outcome_helper(self, results, eval_list, outcome_dict):
+        def output_node(output_result, output_eval_list, output_outcome_dict):
+            # in this case, it is the rule checking component
+            evaluation_outcome = {}
+            if any(
+                [
+                    key.startswith("INVALID_") and key.endswith("_CONTEXT")
+                    for key in output_result
+                ]
+            ):
+                evaluation_outcome["invalid_msg"] = "".join(
+                    [output_result[key] for key in output_result]
+                )
+                output_outcome_dict[RCTOutcomeLabel.UNDETERMINED] += 1
+            else:
+                outcome_label = output_result["result"]
+                if outcome_label == RCTOutcomeLabel.PASS:
+                    output_outcome_dict[RCTOutcomeLabel.PASS] += 1
+                if outcome_label == RCTOutcomeLabel.FAILED:
+                    output_outcome_dict[RCTOutcomeLabel.FAILED] += 1
+                if outcome_label == RCTOutcomeLabel.UNDETERMINED:
+                    output_outcome_dict[RCTOutcomeLabel.UNDETERMINED] += 1
+                if outcome_label == RCTOutcomeLabel.NOT_APPLICABLE:
+                    output_outcome_dict[RCTOutcomeLabel.NOT_APPLICABLE] += 1
+                evaluation_outcome["data_group_id"] = output_result["id"]
+                evaluation_outcome["outcome"] = outcome_label
+                evaluation_outcome["messages"] = (
+                    output_result["message"]
+                    if output_result.get("message") is not None
+                    else ""
+                )
+                evaluation_outcome["calculated_values"] = (
+                    calc_vals_converter(output_result["calc_vals"])
+                    if output_result.get("calc_vals") is not None
+                    else ""
+                )
+            output_eval_list.append(evaluation_outcome)
+
+        outcome = results["result"]
+        if type(outcome) is str:
+            output_node(results, eval_list, outcome_dict)
+        elif type(outcome) is dict:
+            output_node(outcome, eval_list, outcome_dict)
+        else:
+            for result in outcome:
+                self._rule_outcome_helper(result, eval_list, outcome_dict)

--- a/rct229/reports/ashrae9012022/ashrae901_2022_detail_report.py
+++ b/rct229/reports/ashrae9012022/ashrae901_2022_detail_report.py
@@ -75,7 +75,10 @@ class ASHRAE9012022DetailReport(RCTReport):
                     output_outcome_dict[RCTOutcomeLabel.UNDETERMINED] += 1
                 if outcome_label == RCTOutcomeLabel.NOT_APPLICABLE:
                     output_outcome_dict[RCTOutcomeLabel.NOT_APPLICABLE] += 1
-                evaluation_outcome["data_group_id"] = output_result["id"]
+                if "data_group_id" in output_result:
+                    evaluation_outcome["data_group_id"] = output_result["data_group_id"]
+                else:
+                    evaluation_outcome["data_group_id"] = output_result["id"]
                 evaluation_outcome["outcome"] = outcome_label
                 evaluation_outcome["messages"] = (
                     output_result["message"]

--- a/rct229/reports/ashrae9012022/ashrae901_2022_software_test_report.py
+++ b/rct229/reports/ashrae9012022/ashrae901_2022_software_test_report.py
@@ -1,0 +1,75 @@
+import json
+from copy import deepcopy
+
+from rct229 import __version__ as version
+from rct229.report_engine.rct_report import RCTReport
+from rct229.reports.utils import test_evaluation_converter
+
+
+class ASHRAE9012022SoftwareTestReport(RCTReport):
+    def __init__(self):
+        super(ASHRAE9012022SoftwareTestReport, self).__init__()
+        self.title = "ASHRAE STD 229P RULESET CHECKING TOOL"
+        self.purpose = "RCT Ruleset Software Testing Report"
+        self.ruleset = "ASHRAE 90.1-2022 Performance Rating Method (Appendix G)"
+        self.ruleset_report_file = f"{self.__class__.__name__}.json"
+
+    def initialize_ruleset_report(self, rule_outcome=None):
+        report_json = {}
+        report_json["title"] = self.title
+        report_json["purpose"] = self.purpose
+        report_json["tool_name"] = self.tool
+        report_json["tool_version"] = self.version
+        report_json["ruleset"] = self.ruleset
+        report_json["date_run"] = self.date_run
+        report_json["schema_version"] = self.schema_version
+        report_json["rule_tests"] = []
+
+        return report_json
+
+    def generate_rule_report(self, rule_test_dict, outcome_dict):
+        # Sum up the outcomes for every rule unit test evaluation in this rule test. The outcome of this is used by
+        # the calculate_rule_outcome function to determine the overall actual_rule_unit_test_evaluation_outcome
+        test_evaluations = []
+        for test_evaluation in rule_test_dict["rule_unit_test_evaluation"]:
+            result = test_evaluation["result"]
+            outcome_dict[result] += 1
+            test_evaluations.append(test_evaluation_converter(test_evaluation))
+        rule_test_dict["rule_unit_test_evaluation"] = test_evaluations
+        return rule_test_dict
+
+    def add_rule_to_ruleset_report(self, ruleset_report, rule_test_dict, rule_outcome):
+        # Record outcome of aggregated pass/fails as determined by calculate_rule_outcome
+        rule_test_dict["actual_rule_unit_test_evaluation_outcome"] = rule_outcome
+
+        # Pull out the expected outcome to compare it with the actual outcome
+        expected_outcome = rule_test_dict["expected_rule_unit_test_evaluation_outcome"]
+
+        # Record agreement between expected and actual outcome
+        rule_test_dict["rule_unit_test_outcome_agreement"] = (
+            expected_outcome == rule_outcome
+        )
+
+        # Reorder keys to match intended order
+        key_order = [
+            "rule_id",
+            "test_id",
+            "test_description",
+            "ruleset_section",
+            "ruleset_section_title",
+            "evaluation_type",
+            "rule_unit_test_outcome_agreement",
+            "expected_rule_unit_test_evaluation_outcome",
+            "actual_rule_unit_test_evaluation_outcome",
+            "rule_unit_test_evaluation",
+        ]
+
+        # Create new dictionary with proper order of keys
+        ordered_rule_test_dict = {key: rule_test_dict[key] for key in key_order}
+
+        # Append ruletest to ruletest report
+        ruleset_report["rule_tests"].append(deepcopy(ordered_rule_test_dict))
+
+    def save_ruleset_report(self, ruleset_report, report_dir):
+        with open(report_dir, "w") as output_report:
+            output_report.write(json.dumps(ruleset_report, indent=4))

--- a/rct229/reports/ashrae9012022/ashrae901_2022_summary_report.py
+++ b/rct229/reports/ashrae9012022/ashrae901_2022_summary_report.py
@@ -1,0 +1,195 @@
+import re
+
+from pydash import find
+from rct229.report_engine.rct_report import RCTReport
+from rct229.rule_engine.rct_outcome_label import RCTOutcomeLabel
+from rct229.rulesets.ashrae9012022 import section_dict, section_list
+
+
+class ASHRAE9012022SummaryReport(RCTReport):
+    def __init__(self):
+        super(ASHRAE9012022SummaryReport, self).__init__()
+        self.title = "ASHRAE STD 229P RULESET CHECKING TOOL"
+        self.purpose = "Summary Report"
+        self.ruleset = "ASHRAE 90.1-2019 Performance Rating Method (Appendix G)"
+        self.ruleset_report_file = f"{self.__class__.__name__}.md"
+
+    def initialize_ruleset_report(self, rule_outcome=None):
+
+        self.ruleset_outcome = {
+            name: {
+                RCTOutcomeLabel.PASS: 0,
+                RCTOutcomeLabel.FAILED: 0,
+                RCTOutcomeLabel.UNDETERMINED: 0,
+                RCTOutcomeLabel.NOT_APPLICABLE: 0,
+            }
+            for name in section_list
+        }
+
+        rpd_files = rule_outcome["rpd_files"]
+        user_match = find(rpd_files, lambda item: item["ruleset_model_type"] == "USER")
+        proposed_match = find(
+            rpd_files, lambda item: item["ruleset_model_type"] == "PROPOSED"
+        )
+        baseline_0_match = find(
+            rpd_files, lambda item: item["ruleset_model_type"] == "BASELINE_0"
+        )
+        baseline_90_match = find(
+            rpd_files, lambda item: item["ruleset_model_type"] == "BASELINE_90"
+        )
+        baseline_180_match = find(
+            rpd_files, lambda item: item["ruleset_model_type"] == "BASELINE_180"
+        )
+        baseline_270_match = find(
+            rpd_files, lambda item: item["ruleset_model_type"] == "BASELINE_270"
+        )
+
+        self.summary_report = f"""
+## {self.title}
+### {self.purpose} 
+##### {self.ruleset}
+##### Date: {self.date_run}
+
+### RMD Files
+- user: {user_match["file_name"] if user_match else "N/A"}
+- proposed: {proposed_match["file_name"] if proposed_match else "N/A"}
+- baseline_0: {baseline_0_match["file_name"] if baseline_0_match else "N/A"}
+- baseline_90: {baseline_90_match["file_name"] if baseline_90_match else "N/A"}
+- baseline_180: {baseline_180_match["file_name"] if baseline_180_match else "N/A"}
+- baseline_270: {baseline_270_match["file_name"] if baseline_270_match else "N/A"}
+
+### Summary: All Primary Rules
+|                              | All | Performance Calculations | Schedules Setpoints | Envelope | Lighting | HVAC General |  Service Hot Water | Receptacles | Transformers | Elevator | HVAC-HotWaterSide | HVAC - ChilledWaterSide | HVAC-AirSide | HVAC-General| HVAC-Baseline
+|:----------------------------:|:---:|:--------:|:--------:|:--------:|:--------:|:-----------:|:------------:|:------------:|:--------------:|:--------------:|:--------------:|:--------------:|:--------------:|:--------------:|:-----------:|
+Replace-Rules
+Replace-Pass
+Replace-Fail
+Replace-Not_Applicable
+Replace-Undetermined
+
+### Rule Evaluations
+        """
+
+    def generate_rule_report(self, rule_outcome, outcome_dict):
+        def _parse_result_helper(result):
+            if isinstance(result, str):
+                outcome_dict[result] += 1
+                return outcome_dict
+            elif isinstance(result, list):
+                for element in result:
+                    _parse_result_helper(element)
+                if (
+                    sum(outcome_dict.values()) == 0
+                ):  # if result is empty, fill up with `NOT_APPLICABLE` (for now) # TODO check whether empty result is resolved
+                    outcome_dict[RCTOutcomeLabel.NOT_APPLICABLE] = 1
+                return outcome_dict
+            elif isinstance(result, dict):
+                _parse_result_helper(result["result"])
+
+        # count each rule's pass/fail/undetermined/not_applicable
+        rule_outcome_result_dict = _parse_result_helper(rule_outcome["result"])
+
+        # sum up overall rule numbers
+        # self.ruleset_outcome_count_helper(rule_outcome["id"], rule_outcome_result_dict)
+
+        # determine whether overall outcome is pass/fail/undetermined/not_applicable
+        overall_result = self.calculate_rule_outcome(rule_outcome_result_dict)
+        self.ruleset_outcome[section_dict[rule_outcome["id"].split("-")[0]]][
+            overall_result
+        ] += 1
+        self.ruleset_outcome["All"][overall_result] += 1
+
+        # calculate pass/fail/undetermined/not applicable rate
+        no_of_applicable_component = sum(rule_outcome_result_dict.values())
+        multiplier = 100 / no_of_applicable_component
+        pass_rate = int(rule_outcome_result_dict[RCTOutcomeLabel.PASS] * multiplier)
+        fail_rate = int(rule_outcome_result_dict[RCTOutcomeLabel.FAILED] * multiplier)
+        undetermined_rate = int(
+            rule_outcome_result_dict[RCTOutcomeLabel.UNDETERMINED] * multiplier
+        )
+        not_applicable_rate = int(
+            rule_outcome_result_dict[RCTOutcomeLabel.NOT_APPLICABLE] * multiplier
+        )
+
+        one_rule_report = f"""
+  - **Rule Id**: {rule_outcome["id"]}
+    - **Description**: {rule_outcome["description"]}
+    - **90.1-2019 Section**: {rule_outcome['standard_section']}
+    - **Overall Rule Evaluation Outcome**: {overall_result}
+    - **Number of applicable components**: {no_of_applicable_component} 
+      
+      | Pass %: {pass_rate}| Fail %: {fail_rate}| Not applicable %: {not_applicable_rate}| Undetermined %: {undetermined_rate}| 
+      |:--------------:|:--------------:|:--------------:|:--------------:|
+        """
+        return "".join(
+            filter(
+                None, [self._section_name_helper(rule_outcome["id"]), one_rule_report]
+            )
+        )
+
+    def add_rule_to_ruleset_report(self, ruleset_report, rule_report, rule_outcome):
+        self.summary_report = "".join([self.summary_report, rule_report])
+
+    def save_ruleset_report(self, ruleset_report, report_dir):
+        overall_rules_count = {name: 0 for name in section_list}
+
+        for key in self.ruleset_outcome:
+            for outcome in [
+                RCTOutcomeLabel.PASS,
+                RCTOutcomeLabel.FAILED,
+                RCTOutcomeLabel.UNDETERMINED,
+                RCTOutcomeLabel.NOT_APPLICABLE,
+            ]:
+                overall_rules_count[key] += self.ruleset_outcome[key][outcome]
+
+        (
+            rules_line,
+            pass_line,
+            fail_line,
+            not_applicable_line,
+            undetermined_line,
+        ) = self._generate_line(self.ruleset_outcome, overall_rules_count)
+
+        self.summary_report = re.sub("Replace-Rules", rules_line, self.summary_report)
+        self.summary_report = re.sub("Replace-Pass", pass_line, self.summary_report)
+        self.summary_report = re.sub("Replace-Fail", fail_line, self.summary_report)
+        self.summary_report = re.sub(
+            "Replace-Not_Applicable", not_applicable_line, self.summary_report
+        )
+        self.summary_report = re.sub(
+            "Replace-Undetermined", undetermined_line, self.summary_report
+        )
+
+        with open(report_dir, "w", encoding="utf-8") as output_report:
+            output_report.write(self.summary_report)
+
+    def _section_name_helper(self, rule_outcome):
+        section_no = rule_outcome.split("-")[0]
+        if f"Section: {section_dict[section_no]}" not in self.summary_report:
+            return f"""
+### Section: {section_dict[section_no]}
+            """
+        else:
+            return None
+
+    def _generate_line(self, outcome_data, overall_rules_count):
+        rule_line = "|Rules|"
+        pass_line = "|Pass|"
+        fail_line = "|fail|"
+        not_applicable_line = f"|Not Applicable|"
+        undetermined_line = f"|Undetermined (manual review)|"
+
+        for section_name, count in overall_rules_count.items():
+            rule_line += f"{overall_rules_count[section_name]}|"
+
+        for section in section_list:
+            pass_line += f"{outcome_data[section][RCTOutcomeLabel.PASS]}|"
+            fail_line += f"{outcome_data[section][RCTOutcomeLabel.FAILED]}|"
+            not_applicable_line += (
+                f"{outcome_data[section][RCTOutcomeLabel.NOT_APPLICABLE]}|"
+            )
+            undetermined_line += (
+                f"{outcome_data[section][RCTOutcomeLabel.UNDETERMINED]}|"
+            )
+
+        return rule_line, pass_line, fail_line, not_applicable_line, undetermined_line

--- a/rct229/rule_engine/partial_rule_definition.py
+++ b/rct229/rule_engine/partial_rule_definition.py
@@ -16,7 +16,7 @@ class PartialRuleDefinition(RuleDefinitionBase):
         required_fields=None,
         manual_check_required_msg="",
         not_applicable_msg="",
-        precision: Mapping[str, RCTPrecision] = None,
+        precision: Mapping[str, dict[str, float]] = None,
     ):
         """Base class for all Partial Rule definitions (secondary)
 

--- a/rct229/rule_engine/partial_rule_definition_test.py
+++ b/rct229/rule_engine/partial_rule_definition_test.py
@@ -27,6 +27,7 @@ def test__rule_definition_base__evaluate__with_true_secondary_rule_check():
         data={"outcome": True},
     ) == {
         **DERIVED_RULE_outcome_base,
+        "data_group_id": 1,
         "result": "UNDETERMINED",
         "primary_rule": False,
         "message": "Manual check required message",
@@ -39,6 +40,7 @@ def test__rule_definition_base__evaluate__with_false_secondary_rule_check():
         data={"outcome": False},
     ) == {
         **DERIVED_RULE_outcome_base,
+        "data_group_id": 1,
         "result": "NOT_APPLICABLE",
         "primary_rule": False,
         "message": "Not applicable message",

--- a/rct229/rule_engine/rule_base.py
+++ b/rct229/rule_engine/rule_base.py
@@ -35,7 +35,7 @@ class RuleDefinitionBase:
         fail_msg: str = "",
         pass_msg: str = "",
         not_applicable_msg: str = "",
-        precision: Mapping[str, RCTPrecision] = None,
+        precision: Mapping[str, dict[str, float]] = None,
     ):
         """Base class for all Rule definitions
 

--- a/rct229/rule_engine/rule_base.py
+++ b/rct229/rule_engine/rule_base.py
@@ -177,6 +177,20 @@ class RuleDefinitionBase:
         if isinstance(context_or_string, RuleSetModels):
             context = context_or_string
 
+            for ruleset_model in context.get_ruleset_model_types():
+                model_context = context[ruleset_model]
+
+                if isinstance(model_context, dict):
+                    if model_context.get("id"):
+                        outcome["data_group_id"] = model_context["id"]
+                        break
+
+                elif isinstance(model_context, list):
+                    for item in model_context:
+                        if isinstance(item, dict) and item.get("id"):
+                            outcome["data_group_id"] = item["id"]
+                            break
+
             # Check the context for general validity
             context_validity_dict = self.check_context_validity(context, data)
             # If the context is valid, context_validity_dict will be the falsey {}

--- a/rct229/rule_engine/rule_base_test.py
+++ b/rct229/rule_engine/rule_base_test.py
@@ -121,6 +121,7 @@ def test__rule_definition_base__evaluate__with_missing_baseline():
 def test__rule_definition_base__evaluate__with_false_is_applicable():
     assert DERIVED_RULE.evaluate(RMDS_WITH_MATCHING_USER_AND_BASELINE, data="NA") == {
         **BASE_RULE_1_OUTCOME_BASE,
+        "data_group_id": 1,
         "result": "NOT_APPLICABLE",
         "message": "Not applicable message",
     }
@@ -131,6 +132,7 @@ def test__rule_definition_base__evaluate__with_true_manual_check_required():
         RMDS_WITH_MATCHING_USER_AND_BASELINE, data="MANUAL_CHECK_REQUIRED"
     ) == {
         **DERIVED_RULE_outcome_base,
+        "data_group_id": 1,
         "result": "UNDETERMINED",
         "message": "Manual check required message",
     }
@@ -139,6 +141,7 @@ def test__rule_definition_base__evaluate__with_true_manual_check_required():
 def test__rule_definition_base__evaluate__with_true_rule_check():
     assert DERIVED_RULE.evaluate(RMDS_WITH_MATCHING_USER_AND_BASELINE, data=True) == {
         **DERIVED_RULE_outcome_base,
+        "data_group_id": 1,
         "result": "PASSED",
     }
 
@@ -146,6 +149,7 @@ def test__rule_definition_base__evaluate__with_true_rule_check():
 def test__rule_definition_base__evaluate__with_true_rule_check():
     assert DERIVED_RULE.evaluate(RMDS_WITH_MATCHING_USER_AND_BASELINE, data=False) == {
         **DERIVED_RULE_outcome_base,
+        "data_group_id": 1,
         "result": "FAILED",
     }
 

--- a/rct229/rulesets/ashrae9012019/__init__.py
+++ b/rct229/rulesets/ashrae9012019/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "section23",
     "section_list",
     "section_dict",
+    "SHORT_NAME",
     "BASELINE_0",
     "BASELINE_90",
     "BASELINE_180",

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/get_baseline_system_types.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/get_baseline_system_types.py
@@ -54,7 +54,7 @@ from rct229.utils.jsonpath_utils import find_all
 
 
 @memoize
-def get_baseline_system_types(rmd_b: dict) -> dict[HVAC_SYS, list[str]]:
+def get_baseline_system_types(rmd_b: dict) -> dict[str, list[str]]:
     """
     Identify all the baseline system types modeled in a B-RMD.
 

--- a/rct229/rulesets/ashrae9012019/ruleset_functions/get_primary_secondary_loops_dict.py
+++ b/rct229/rulesets/ashrae9012019/ruleset_functions/get_primary_secondary_loops_dict.py
@@ -28,20 +28,14 @@ def get_primary_secondary_loops_dict(rmd_b: dict) -> dict[str, list[str]]:
     """
     Get the list of primary and secondary loops for CHW for a B-RMD.
 
-    Parameters
-    ----------
-    rmd_b: A baseline ruleset model description
-
-    Returns: primary_secondary_loops_dict
-    A dictionary that saves pairs of primary and secondary loops for
-    baseline chilled water system, e.g. {primary_loop_1.id: [secondary_loop_1.id,
-    secondary_loop2.id], primary_loop_2.id: [secondary_loop3.id]]}. If B-RMD does
-    not have primary-secondary loop configuration setup, return an empty dictionary.
+    Returns a dictionary mapping each primary chilled water loop id to a list
+    of associated secondary loop ids. Primary loops are always returned if
+    they are referenced by a chiller, regardless of whether secondary loops
+    are present or identifiable.
     """
     baseline_hvac_system_dict = get_baseline_system_types(rmd_b)
 
-    # Use find_all here to avoid including None for missing cooling_loops
-    # Note: a chiller_loop id could appear more than once in this list
+    # Loops referenced by chillers → candidate primary loops
     chiller_loop_ids = find_all("$.chillers[*].cooling_loop", rmd_b)
 
     applicable_hvac_ids = [
@@ -49,6 +43,7 @@ def get_primary_secondary_loops_dict(rmd_b: dict) -> dict[str, list[str]]:
         for sys_type in APPLICABLE_SYS_TYPES
         for hvac_id in baseline_hvac_system_dict[sys_type]
     ]
+
     applicable_hvac_systems = [
         hvac
         for hvac in find_all(
@@ -57,36 +52,33 @@ def get_primary_secondary_loops_dict(rmd_b: dict) -> dict[str, list[str]]:
         )
         if hvac["id"] in applicable_hvac_ids
     ]
+
+    # Loops serving non-process CHW coils → candidate secondary loops
     non_process_chw_coil_loop_ids = [
-        # Get hvac["cooling_system"]["chilled_water_loop"] or raise exception
         getattr_(hvac, "hvac system", "cooling_system", "chilled_water_loop")
         for hvac in applicable_hvac_systems
     ]
-    # Initialize variables
-    primary_loops = []
-    tmp_primary_secondary_loops_dict = dict()
 
-    # Iterate through cooling type fluid loops
+    primary_secondary_loops_dict: dict[str, list[str]] = {}
+
+    # Iterate through all cooling fluid loops
     for chilled_fluid_loop in find_all(
         f'fluid_loops[*][?(@.type="{FLUID_LOOP.COOLING}")]', rmd_b
     ):
-        cfl_id = chilled_fluid_loop["id"]
-        if cfl_id in chiller_loop_ids and cfl_id in non_process_chw_coil_loop_ids:
-            # No loop in baseline shall be primary only
-            tmp_primary_secondary_loops_dict = dict()
-            primary_loops = []
-            break
-        elif cfl_id in chiller_loop_ids:
-            if all(
-                child_loop["id"] in non_process_chw_coil_loop_ids
-                for child_loop in getattr_(
-                    chilled_fluid_loop, "FluidLoop", "child_loops"
-                )
-            ):
-                primary_loops.append(chilled_fluid_loop)
+        loop_id = chilled_fluid_loop["id"]
 
-    for primary_loop in primary_loops:
-        tmp_primary_secondary_loops_dict[primary_loop["id"]] = find_all(
-            "$.child_loops[*].id", primary_loop
-        )
-    return tmp_primary_secondary_loops_dict
+        # Primary loop = referenced by at least one chiller
+        if loop_id not in chiller_loop_ids:
+            continue
+
+        # Associate secondary loops
+        secondary_loop_ids = [
+            child_loop["id"]
+            for child_loop in chilled_fluid_loop.get("child_loops", [])
+            if child_loop["id"] in non_process_chw_coil_loop_ids
+        ]
+
+        # Always include the primary loop, even if no secondaries are found
+        primary_secondary_loops_dict[loop_id] = secondary_loop_ids
+
+    return primary_secondary_loops_dict

--- a/rct229/rulesets/ashrae9012019/section22/section22rule10.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule10.py
@@ -64,15 +64,12 @@ class PRM9012019Rule41z21(RuleDefinitionListIndexedBase):
 
         primary_secondary_loop_dict = get_primary_secondary_loops_dict(rmd_b)
 
-        return (
-            any(
-                [
-                    available_type in APPLICABLE_SYS_TYPES
-                    for available_type in available_type_list
-                ]
-            )
-            and len(primary_secondary_loop_dict) > 0
-        )
+        return any(
+            [
+                available_type in APPLICABLE_SYS_TYPES
+                for available_type in available_type_list
+            ]
+        ) and any(primary_secondary_loop_dict.values())
 
     def create_data(self, context, data):
         rmd_b = context.BASELINE_0

--- a/rct229/rulesets/ashrae9012019/section22/section22rule11.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule11.py
@@ -59,15 +59,12 @@ class PRM9012019Rule57w94(RuleDefinitionListIndexedBase):
 
         primary_secondary_loop_dict = get_primary_secondary_loops_dict(rmd_b)
 
-        return (
-            any(
-                [
-                    available_type in APPLICABLE_SYS_TYPES
-                    for available_type in available_type_list
-                ]
-            )
-            and primary_secondary_loop_dict
-        )
+        return any(
+            [
+                available_type in APPLICABLE_SYS_TYPES
+                for available_type in available_type_list
+            ]
+        ) and any(primary_secondary_loop_dict.values())
 
     def create_data(self, context, data):
         rmd_b = context.BASELINE_0

--- a/rct229/rulesets/ashrae9012019/section22/section22rule24.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule24.py
@@ -59,15 +59,12 @@ class PRM9012019Rule47d94(RuleDefinitionListIndexedBase):
         ]
         primary_secondary_loop_dict = get_primary_secondary_loops_dict(rmd_b)
 
-        return (
-            any(
-                [
-                    available_type in APPLICABLE_SYS_TYPES
-                    for available_type in available_type_list
-                ]
-            )
-            and primary_secondary_loop_dict
-        )
+        return any(
+            [
+                available_type in APPLICABLE_SYS_TYPES
+                for available_type in available_type_list
+            ]
+        ) and any(primary_secondary_loop_dict.values())
 
     def create_data(self, context, data):
         rmd_b = context.BASELINE_0
@@ -77,8 +74,11 @@ class PRM9012019Rule47d94(RuleDefinitionListIndexedBase):
     # filter to only keep loops that have secondary loop(s)
     def list_filter(self, context_item, data):
         pump_b = context_item.BASELINE_0
-        primary_loop_ids = data["primary_secondary_loops_dict"]
-        return pump_b["loop_or_piping"] in primary_loop_ids
+        primary_secondary_loops_dict = data["primary_secondary_loops_dict"]
+        return (
+            pump_b["loop_or_piping"] in primary_secondary_loops_dict
+            and len(primary_secondary_loops_dict[pump_b["loop_or_piping"]]) > 0
+        )
 
     class PrimaryPumpRule(RuleDefinitionBase):
         def __init__(self):

--- a/rct229/rulesets/ashrae9012019/section22/section22rule25.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule25.py
@@ -79,7 +79,7 @@ class PRM9012019Rule03q09(RuleDefinitionListIndexedBase):
                     for available_type in available_sys_types
                 ]
             )
-            and primary_secondary_loop_dict
+            and any(primary_secondary_loop_dict.values())
         )
 
     def create_data(self, context, data):
@@ -90,8 +90,10 @@ class PRM9012019Rule03q09(RuleDefinitionListIndexedBase):
     def list_filter(self, context_item, data):
         fluid_loop = context_item.BASELINE_0
         primary_secondary_loops_dict = data["primary_secondary_loops_dict"]
-        primary_loop_ids = primary_secondary_loops_dict
-        return fluid_loop["id"] in primary_loop_ids
+        return (
+            fluid_loop["id"] in primary_secondary_loops_dict
+            and len(primary_secondary_loops_dict[fluid_loop["id"]]) > 0
+        )
 
     class PrimaryCoolingFluidLoopRule(RuleDefinitionBase):
         def __init__(self):

--- a/rct229/rulesets/ashrae9012019/section22/section22rule26.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule26.py
@@ -54,15 +54,12 @@ class PRM9012019Rule18j38(RuleDefinitionListIndexedBase):
         ]
         primary_secondary_loop_dict = get_primary_secondary_loops_dict(rmd_b)
 
-        return (
-            any(
-                [
-                    available_type in APPLICABLE_SYS_TYPES
-                    for available_type in available_sys_types
-                ]
-            )
-            and len(primary_secondary_loop_dict) > 0
-        )
+        return any(
+            [
+                available_type in APPLICABLE_SYS_TYPES
+                for available_type in available_sys_types
+            ]
+        ) and any(primary_secondary_loop_dict.values())
 
     def create_data(self, context, data):
         rmd_b = context.BASELINE_0
@@ -71,8 +68,11 @@ class PRM9012019Rule18j38(RuleDefinitionListIndexedBase):
 
     def list_filter(self, context_item, data):
         fluid_loop = context_item.BASELINE_0
-        primary_loop_ids = data["primary_secondary_loops_dict"]
-        return fluid_loop["id"] in primary_loop_ids
+        primary_secondary_loops_dict = data["primary_secondary_loops_dict"]
+        return (
+            fluid_loop["id"] in primary_secondary_loops_dict
+            and len(primary_secondary_loops_dict[fluid_loop["id"]]) > 0
+        )
 
     class PrimaryCoolingFluidLoop(RuleDefinitionBase):
         def __init__(self):

--- a/rct229/rulesets/ashrae9012019/section22/section22rule33.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule33.py
@@ -49,10 +49,6 @@ class PRM9012019Rule88r57(RuleDefinitionBase):
             for hvac_type in baseline_system_types_dict
             if len(baseline_system_types_dict[hvac_type]) > 0
         ]
-        # There is no point to check primary secondary loop in the applicable function
-        # because the get_primary_secondary_loops_dict returns nothing if any cooling loop is
-        # modeled as a primary only loop
-        # primary_secondary_loop_dict = get_primary_secondary_loops_dict(rmd_b)
 
         return any(
             [

--- a/rct229/rulesets/ashrae9012019/section22/section22rule34.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule34.py
@@ -71,7 +71,10 @@ class PRM9012019Rule36t85(RuleDefinitionListIndexedBase):
         fluid_loops_b = context_item.BASELINE_0
         primary_secondary_loop_dict = data["primary_secondary_loop_dict"]
 
-        return fluid_loops_b["id"] in primary_secondary_loop_dict
+        return (
+            fluid_loops_b["id"] in primary_secondary_loop_dict
+            and len(primary_secondary_loop_dict[fluid_loops_b["id"]]) > 0
+        )
 
     class CoolingFluidLoopRule(RuleDefinitionBase):
         def __init__(self):

--- a/rct229/rulesets/ashrae9012019/section22/section22rule36.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule36.py
@@ -62,15 +62,12 @@ class PRM9012019Rule01b91(RuleDefinitionListIndexedBase):
         # primary secondary loop
         primary_secondary_loop_dict = get_primary_secondary_loops_dict(rmd_b)
 
-        return (
-            any(
-                [
-                    available_type in APPLICABLE_SYS_TYPES
-                    for available_type in available_type_list
-                ]
-            )
-            and primary_secondary_loop_dict
-        )
+        return any(
+            [
+                available_type in APPLICABLE_SYS_TYPES
+                for available_type in available_type_list
+            ]
+        ) and any(primary_secondary_loop_dict.values())
 
     def create_data(self, context, data):
         rmd_b = context.BASELINE_0

--- a/rct229/rulesets/ashrae9012019/section22/section22rule7.py
+++ b/rct229/rulesets/ashrae9012019/section22/section22rule7.py
@@ -58,11 +58,18 @@ class PRM9012019Rule52s13(RuleDefinitionBase):
 
     def get_calc_vals(self, context, data=None):
         rmd_b = context.BASELINE_0
-        num_primary_loops = len(get_primary_secondary_loops_dict(rmd_b))
+        primary_secondary_loops_dict = get_primary_secondary_loops_dict(rmd_b)
+        num_primary_secondary_loops = len(
+            [
+                primary_loop
+                for primary_loop in primary_secondary_loops_dict
+                if len(primary_secondary_loops_dict[primary_loop]) > 0
+            ]
+        )
 
-        return {"num_primary_loops": num_primary_loops}
+        return {"num_primary_secondary_loops": num_primary_secondary_loops}
 
     def rule_check(self, context, calc_vals=None, data=None):
-        num_primary_loops = calc_vals["num_primary_loops"]
+        num_primary_secondary_loops = calc_vals["num_primary_secondary_loops"]
 
-        return num_primary_loops != 0
+        return num_primary_secondary_loops != 0

--- a/rct229/rulesets/ashrae9012022/__init__.py
+++ b/rct229/rulesets/ashrae9012022/__init__.py
@@ -12,6 +12,8 @@ __all__ = [
     "section12",
     "section21",
     "section22",
+    "section_list",
+    "section_dict",
     "SHORT_NAME",
     "BASELINE_0",
     "BASELINE_90",

--- a/rct229/utils/assertions.py
+++ b/rct229/utils/assertions.py
@@ -59,7 +59,10 @@ def getattr_(obj: dict, obj_name: str, first_key: str, *remaining_keys: str) -> 
     )
 
     if first_key not in obj:
-        raise MissingKeyException(obj_name, obj["id"], first_key)
+        if "id" in obj:
+            raise MissingKeyException(obj_name, obj["id"], first_key)
+        else:
+            raise MissingKeyException(obj_name, "", first_key)
     val = obj[first_key]
 
     return (

--- a/rct229/utils/pint_utils.py
+++ b/rct229/utils/pint_utils.py
@@ -1,7 +1,4 @@
-import functools
-import operator
 from dataclasses import dataclass
-
 from pint import Quantity
 
 from rct229.schema.config import ureg
@@ -189,6 +186,8 @@ def calcq_to_str(unit_system, obj) -> str:
     """
     if isinstance(obj, CalcQ):
         retval = None if obj.q is None else obj.to_str(unit_system)
+    elif isinstance(obj, Quantity):
+        retval = str(obj)
     elif isinstance(obj, list):
         retval = [calcq_to_str(unit_system, item) for item in obj]
     elif isinstance(obj, dict):


### PR DESCRIPTION
This PR includes adjustment to `get_primary_secondary_loops_dict` and the rules that call that function so that the reported number of primary loops and secondary loops can be accurate. 

This removes inferred meaning that all loops returned by the function are in primary/secondary configuration, and is handled accordingly in each rule.

I did not realize how many files I would need to change before starting this work. Let me know if you would prefer I separate out the primary/secondary refactoring to a different PR.